### PR TITLE
Replace Date object with dayjs in parseDate function

### DIFF
--- a/logics/date/parseDate.ts
+++ b/logics/date/parseDate.ts
@@ -1,3 +1,5 @@
-export const parseDate = (isoDate: string) => {
-  return new Date(isoDate).toLocaleDateString();
+import dayjs from "dayjs";
+
+export const parseDate = (isoDate: string): string => {
+  return dayjs(isoDate).format("YYYY/MM/DD");
 };


### PR DESCRIPTION
Dayjs is used instead of the native Date object for date parsing to have more accurate and consistent results across different browsers and environments. This also allows for cleaner date formatting.