### PR TITLE
Limit entry data fetching to 10 entries

### DIFF
--- a/app/logics/api/fetchAllEntryData.ts
+++ b/app/logics/api/fetchAllEntryData.ts
@@ -45,13 +45,16 @@ export const fetchAllEntryData = async (): Promise<EntryType[]> => {
     });
 
   await Promise.allSettled(
-    (result as EntryType[]).map(async (entry) => {
-      if (entry.url) {
-        const htmlText = await fetchHTMLText(entry.url);
-        const htmlDocument = creteHTMLDocument(htmlText);
-        entry.metaInfo = parseMetaInfo(htmlDocument);
-      }
-    }),
+    (result as EntryType[])
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      .filter((_, index) => index < 10)
+      .map(async (entry) => {
+        if (entry.url) {
+          const htmlText = await fetchHTMLText(entry.url);
+          const htmlDocument = creteHTMLDocument(htmlText);
+          entry.metaInfo = parseMetaInfo(htmlDocument);
+        }
+      }),
   );
 
   return result;


### PR DESCRIPTION
The modification limits the fetching and parsing of metadata for entries. Prior to this change, the code was attempting to fetch and parse metadata for all entries. However, due to issues with latency and memory usage, this has now been limited to the first 10 entries. This change is expected