### PR TITLE
Refactor scraping logic to a separate function

### DIFF
--- a/app/entry/[slug]/page.tsx
+++ b/app/entry/[slug]/page.tsx
@@ -10,9 +10,7 @@ import { DetailHTML } from "../../components/concerns/DetailHTML/DetailHTML";
 import { LinkCard } from "../../components/common/LinkCard";
 import { WithSiteTitle } from "../../constants";
 import { metadata } from "../../layout";
-import { fetchHTMLText } from "../../logics/scraping/fetchHTMLText";
-import { creteHTMLDocument } from "../../logics/scraping/creteHTMLDocument";
-import { parseMetaInfo } from "../../logics/scraping/parseMetaInfo";
+import { getMetaDataForEntryDataList } from "../../logics/scraping/getMetaDataForEntryDataList";
 
 export const generateStaticParams = async (): Promise<string[]> => {
   const portfolioData = await fetchAllEntryData();
@@ -26,11 +24,7 @@ const getEntryData = async (slug: string) => {
     throw new Error("entryData is null");
   }
 
-  if (entryData.url) {
-    const htmlText = await fetchHTMLText(entryData.url);
-    const htmlDocument = creteHTMLDocument(htmlText);
-    entryData.metaInfo = parseMetaInfo(htmlDocument);
-  }
+  await getMetaDataForEntryDataList([entryData]);
 
   return {
     entryData,

--- a/app/logics/scraping/getMetaDataForEntryDataList.ts
+++ b/app/logics/scraping/getMetaDataForEntryDataList.ts
@@ -1,0 +1,19 @@
+import type { EntryType } from "../../types/EntryType";
+import { fetchHTMLText } from "./fetchHTMLText";
+import { creteHTMLDocument } from "./creteHTMLDocument";
+import { parseMetaInfo } from "./parseMetaInfo";
+
+export const getMetaDataForEntryDataList = async (
+  entryDataList: EntryType[],
+): Promise<void> => {
+  await Promise.allSettled(
+    entryDataList.map(async (entry) => {
+      if (entry.url) {
+        const htmlText = await fetchHTMLText(entry.url);
+        const htmlDocument = creteHTMLDocument(htmlText);
+        entry.metaInfo = parseMetaInfo(htmlDocument);
+      }
+      return entry;
+    }),
+  );
+};

--- a/app/medium/[slug]/page.tsx
+++ b/app/medium/[slug]/page.tsx
@@ -7,6 +7,7 @@ import { Copyright } from "../../components/concerns/Copyright";
 import { fetchMedia } from "../../logics/api/fetchMedia";
 import { WithSiteTitle } from "../../constants";
 import { metadata } from "../../layout";
+import { getMetaDataForEntryDataList } from "../../logics/scraping/getMetaDataForEntryDataList";
 
 export const generateStaticParams = async (): Promise<string[]> => {
   const mediumData = await fetchMedia();
@@ -21,6 +22,8 @@ const getEntryData = async (slug: string) => {
       // paramのmediaが含まれているかどうか？
       entryData.medium?.slug === slug,
   );
+
+  await getMetaDataForEntryDataList(entryDataList);
 
   return {
     entryDataList,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,25 +4,13 @@ import { EntryList } from "./components/concerns/EntryList";
 import { fetchAllEntryData } from "./logics/api/fetchAllEntryData";
 import { Copyright } from "./components/concerns/Copyright";
 import { container } from "./page.css";
-import { fetchHTMLText } from "./logics/scraping/fetchHTMLText";
-import { creteHTMLDocument } from "./logics/scraping/creteHTMLDocument";
-import { parseMetaInfo } from "./logics/scraping/parseMetaInfo";
+import { getMetaDataForEntryDataList } from "./logics/scraping/getMetaDataForEntryDataList";
 
 const getEntryData = async (): Promise<{
   entryDataList: EntryType[];
 }> => {
   const entryDataList = await fetchAllEntryData();
-
-  await Promise.allSettled(
-    entryDataList.map(async (entry) => {
-      if (entry.url) {
-        const htmlText = await fetchHTMLText(entry.url);
-        const htmlDocument = creteHTMLDocument(htmlText);
-        entry.metaInfo = parseMetaInfo(htmlDocument);
-      }
-    }),
-  );
-
+  await getMetaDataForEntryDataList(entryDataList);
   return {
     entryDataList,
   };

--- a/app/tag/[slug]/page.tsx
+++ b/app/tag/[slug]/page.tsx
@@ -7,6 +7,7 @@ import { Copyright } from "../../components/concerns/Copyright";
 import { fetchTagList } from "../../logics/api/fetchTagList";
 import { metadata } from "../../layout";
 import { WithSiteTitle } from "../../constants";
+import { getMetaDataForEntryDataList } from "../../logics/scraping/getMetaDataForEntryDataList";
 
 export const generateStaticParams = async (): Promise<string[]> => {
   const tagData = await fetchTagList();
@@ -22,6 +23,8 @@ const getEntryData = async (slug: string) => {
     // タグ内に、paramのタグが含まれているかどうか？
     return entryData.tags?.some((tagData) => tagData.slug === slug);
   });
+
+  await getMetaDataForEntryDataList(entryDataList);
 
   return {
     entryDataList,


### PR DESCRIPTION
Refactored the logic for scraping meta data into a separate function called getMetaDataForEntryDataList. This was done to remove repetitive code blocks and promote code reusability. We can now easily scrape meta data across multiple files - app/page.tsx, app/medium/[slug]/page.tsx, app/tag/[slug]/page.tsx, and app/entry/[slug]/page.tsx - by calling this new function.