### PR TITLE
Remove 'next/head' import in layout.tsx

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,4 @@
 import type { ReactNode } from "react";
-import Head from "next/head";
 import {
   basicDescription,
   ogImageUrl,
@@ -50,10 +49,9 @@ const RootLayout: NextPage<{ children: ReactNode }> = async ({ children }) => {
 
   return (
     <html lang="ja">
-      <Head>
-        <meta charSet="utf-8" />
+      <head>
         <link rel="apple-touch-icon" href="/apple-icon.png" />
-      </Head>
+      </head>
       <body>
         <div className={root}>
           <div className={wrapper}>


### PR DESCRIPTION
The import of 'next/head' and its use in layout.tsx file were removed due to deprecation in the newer version of Next.js. Replaced with standard html head tag and updated its children accordingly.