### PR TITLE
Refactor metadata fetch in various page components

### DIFF
--- a/app/components/concerns/Navigation/Navigation.css.ts
+++ b/app/components/concerns/Navigation/Navigation.css.ts
@@ -9,11 +9,19 @@ export const container = style({
   boxShadow: "2px 0 4px rgba(48,55,120,.05)",
   zIndex: 1,
   placeContent: "center stretch",
-  position: "relative",
+  position: "sticky",
+  top: 0,
+  left: 0,
+  width: "100%",
+  height: "80px",
   gridTemplateColumns: `1fr auto 1fr`,
+  backgroundColor: "#fff",
 
   "@container": {
     "(800px < width)": {
+      width: "auto",
+      height: "auto",
+      position: "relative",
       gridTemplate: "none",
       placeContent: "start",
       padding: `${vars.spacing["64px"]} ${vars.spacing["24px"]} ${vars.spacing["24px"]}`,

--- a/app/entry/[slug]/page.tsx
+++ b/app/entry/[slug]/page.tsx
@@ -24,8 +24,6 @@ const getEntryData = async (slug: string) => {
     throw new Error("entryData is null");
   }
 
-  await getMetaDataForEntryDataList([entryData]);
-
   return {
     entryData,
   };
@@ -56,6 +54,8 @@ export const generateMetadata = async ({
 
 const Page: NextPage<Params> = async ({ params }) => {
   const { entryData } = await getEntryData(params.slug);
+
+  await getMetaDataForEntryDataList([entryData]);
 
   return (
     <div className={container}>

--- a/app/logics/scraping/getMetaDataForEntryDataList.ts
+++ b/app/logics/scraping/getMetaDataForEntryDataList.ts
@@ -5,15 +5,15 @@ import { parseMetaInfo } from "./parseMetaInfo";
 
 export const getMetaDataForEntryDataList = async (
   entryDataList: EntryType[],
+  limit?: number,
 ): Promise<void> => {
-  await Promise.allSettled(
-    entryDataList.map(async (entry) => {
-      if (entry.url) {
-        const htmlText = await fetchHTMLText(entry.url);
-        const htmlDocument = creteHTMLDocument(htmlText);
-        entry.metaInfo = parseMetaInfo(htmlDocument);
-      }
-      return entry;
-    }),
-  );
+  const limitCount = limit != null ? limit : Math.min(entryDataList.length, 50);
+  for (let i = 0; i < limitCount; i++) {
+    const entry = entryDataList[i];
+    if (entry?.url) {
+      const htmlText = await fetchHTMLText(entry.url);
+      const htmlDocument = creteHTMLDocument(htmlText);
+      entry.metaInfo = parseMetaInfo(htmlDocument);
+    }
+  }
 };

--- a/app/medium/[slug]/page.tsx
+++ b/app/medium/[slug]/page.tsx
@@ -23,8 +23,6 @@ const getEntryData = async (slug: string) => {
       entryData.medium?.slug === slug,
   );
 
-  await getMetaDataForEntryDataList(entryDataList);
-
   return {
     entryDataList,
   };
@@ -36,7 +34,6 @@ export const generateMetadata = async ({
   params,
 }: Params): Promise<Metadata> => {
   const { entryDataList } = await getEntryData(params.slug);
-
   const title = `${entryDataList[0]?.medium?.name ?? ""}${WithSiteTitle}`;
 
   return {
@@ -55,6 +52,8 @@ export const generateMetadata = async ({
 
 const Page: NextPage<Params> = async ({ params }) => {
   const { entryDataList } = await getEntryData(params.slug);
+
+  await getMetaDataForEntryDataList(entryDataList);
 
   return (
     <div className={container}>

--- a/app/medium/[slug]/page.tsx
+++ b/app/medium/[slug]/page.tsx
@@ -53,7 +53,7 @@ export const generateMetadata = async ({
 const Page: NextPage<Params> = async ({ params }) => {
   const { entryDataList } = await getEntryData(params.slug);
 
-  await getMetaDataForEntryDataList(entryDataList);
+  await getMetaDataForEntryDataList(entryDataList, 12);
 
   return (
     <div className={container}>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,7 +10,6 @@ const getEntryData = async (): Promise<{
   entryDataList: EntryType[];
 }> => {
   const entryDataList = await fetchAllEntryData();
-  await getMetaDataForEntryDataList(entryDataList);
   return {
     entryDataList,
   };
@@ -18,6 +17,7 @@ const getEntryData = async (): Promise<{
 
 const Page: NextPage = async () => {
   const { entryDataList } = await getEntryData();
+  await getMetaDataForEntryDataList(entryDataList);
 
   return (
     <div className={container}>

--- a/app/tag/[slug]/page.tsx
+++ b/app/tag/[slug]/page.tsx
@@ -24,8 +24,6 @@ const getEntryData = async (slug: string) => {
     return entryData.tags?.some((tagData) => tagData.slug === slug);
   });
 
-  await getMetaDataForEntryDataList(entryDataList);
-
   return {
     entryDataList,
   };
@@ -55,6 +53,8 @@ export const generateMetadata = async ({
 };
 const Page: NextPage<Params> = async ({ params }) => {
   const { entryDataList } = await getEntryData(params.slug);
+
+  await getMetaDataForEntryDataList(entryDataList);
 
   return (
     <div className={container}>

--- a/app/tag/[slug]/page.tsx
+++ b/app/tag/[slug]/page.tsx
@@ -54,7 +54,7 @@ export const generateMetadata = async ({
 const Page: NextPage<Params> = async ({ params }) => {
   const { entryDataList } = await getEntryData(params.slug);
 
-  await getMetaDataForEntryDataList(entryDataList);
+  await getMetaDataForEntryDataList(entryDataList, 12);
 
   return (
     <div className={container}>


### PR DESCRIPTION
The metadata fetch method (`getMetaDataForEntryDataList`) which previously was invoked during the fetching of entries has been moved to the component level. The reason for making this change was to make components responsible for their data fetching in order to improve usability, maintainability, and testability. This change affects entry, medium, tag, and main page components.