### PR TITLE
Fix link and update date style

### DIFF
--- a/app/components/concerns/EntryList/EntryList.css.ts
+++ b/app/components/concerns/EntryList/EntryList.css.ts
@@ -84,9 +84,9 @@ export const title = style({
 });
 
 export const publishedDate = style({
-  display: "block",
   fontSize: vars.font.size.xs,
   color: vars.color.text,
+  marginTop: "0",
   selectors: {
     ...hoverTextStyle,
   },

--- a/app/components/concerns/EntryList/EntryList.tsx
+++ b/app/components/concerns/EntryList/EntryList.tsx
@@ -72,9 +72,12 @@ export const EntryList: FC<Props> = ({ listTitle, entryDataList }) => {
               </header>
               <h2 className={titleStyle}>{title}</h2>
               {published_date && (
-                <time dateTime={published_date} className={publishedDate}>
-                  発表日：{parseDate(published_date)}
-                </time>
+                <p className={publishedDate}>
+                  発表日
+                  <time dateTime={published_date}>
+                    {parseDate(published_date)}
+                  </time>
+                </p>
               )}
             </div>
           </Link>

--- a/app/components/concerns/EntryList/EntryList.tsx
+++ b/app/components/concerns/EntryList/EntryList.tsx
@@ -5,7 +5,7 @@ import {
   entryList,
   header,
   info,
-  keyvisual as keyvisualStyle,
+  keyvisual,
   link,
   listTitle as listTitleStyle,
   medium as mediumStyle,
@@ -50,7 +50,7 @@ export const EntryList: FC<Props> = ({ listTitle, entryDataList }) => {
           >
             {metaInfo?.ogImage && (
               <Image
-                className={keyvisualStyle}
+                className={keyvisual}
                 src={createHttpsImage(metaInfo.ogImage)}
                 alt={metaInfo.ogTitle ?? ""}
                 width={960}

--- a/app/components/concerns/EntryList/EntryList.tsx
+++ b/app/components/concerns/EntryList/EntryList.tsx
@@ -43,7 +43,7 @@ export const EntryList: FC<Props> = ({ listTitle, entryDataList }) => {
         return (
           <Link
             key={entryData.id}
-            href={`/entry/${entryData.slug}`}
+            href={href}
             aria-label={entryData.title}
             target={target}
             className={link}

--- a/app/entry/[slug]/page.css.ts
+++ b/app/entry/[slug]/page.css.ts
@@ -66,7 +66,6 @@ export const link = style({
 });
 
 export const publishedDate = style({
-  display: "block",
   fontSize: vars.font.size.xs,
   color: vars.color.text,
 });

--- a/app/entry/[slug]/page.tsx
+++ b/app/entry/[slug]/page.tsx
@@ -86,9 +86,12 @@ const Page: NextPage<Params> = async ({ params }) => {
         </header>
         <h2 className={titleStyle}>{entryData.title}</h2>
         {entryData.published_date && (
-          <time dateTime={entryData.published_date} className={publishedDate}>
-            発表日：{parseDate(entryData.published_date)}
-          </time>
+          <p className={publishedDate}>
+            発表日
+            <time dateTime={entryData.published_date}>
+              {parseDate(entryData.published_date)}
+            </time>
+          </p>
         )}
 
         {/* ビデオ */}


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:
- Style: Removed the `display: "block"` property from the `publishedDate` style in `EntryList.css.ts` and `page.css.ts`.
- Refactor: Modified JSX code in `EntryList.tsx` and `page.tsx` to add a `<p>` element around the published date, wrap it with a `<time>` element, and pass the `href` prop as a variable. Added a label "発表日" before the `<time>` element in `page.tsx`.

> "A touch of style, a refactor profound,
> The published date now wears a new crown.
> With elegance and grace, the changes unfold,
> Enhancing the UI, making it bold."
<!-- end of auto-generated comment: release notes by openai -->