### PR TITLE
Disable PR review automation

### DIFF
--- a/.github/workflows/openai-pr-reviewer.yml
+++ b/.github/workflows/openai-pr-reviewer.yml
@@ -28,3 +28,4 @@ jobs:
           debug: false
           review_simple_changes: false
           review_comment_lgtm: false
+          disable_review: true


### PR DESCRIPTION
Disable the automation for PR reviews in the OpenAI workflow. This change has been made with the intention of conducting PR reviews manually for better quality assurance and control.
<!-- This is an auto-generated comment: release notes by openai -->

### Summary

Release Notes:
- Chore: Disable automation for PR reviews in the OpenAI workflow.
