### PR TITLE
Refactor CSS imports in various components

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata, NextPage } from "next";
 import Link from "next/link";
 import Image from "next/image";
-import { container, list, mainVisual, h1, h2 } from "./page.css";
+import * as styles from "./page.css";
 import { WithSiteTitle } from "../constants";
 
 export const metadata: Metadata = {
@@ -13,10 +13,10 @@ export const metadata: Metadata = {
 
 const AboutPage: NextPage = () => {
   return (
-    <div className={container}>
-      <h1 className={h1}>自己紹介</h1>
+    <div className={styles.container}>
+      <h1 className={styles.h1}>自己紹介</h1>
       <Image
-        className={mainVisual}
+        className={styles.mainVisual}
         src="/ogimage.png"
         width="1200"
         height="630"
@@ -36,8 +36,8 @@ const AboutPage: NextPage = () => {
           TechFeed Pro公認エキスパート
         </Link>
       </p>
-      <h2 className={h2}>書籍</h2>
-      <ul className={list}>
+      <h2 className={styles.h2}>書籍</h2>
+      <ul className={styles.list}>
         <li>
           <Link
             href="https://info.nikkeibp.co.jp/media/NSW/atcl/mag/051600042/"
@@ -68,7 +68,7 @@ const AboutPage: NextPage = () => {
           </Link>
         </li>
       </ul>
-      <h2 className={h2}>技術発信</h2>
+      <h2 className={styles.h2}>技術発信</h2>
       <ul>
         <li>
           <Link href="https://twitter.com/tonkotsuboy_com" target="_blank">
@@ -104,7 +104,7 @@ const AboutPage: NextPage = () => {
           </Link>
         </li>
       </ul>
-      <h2 className={h2}>講師</h2>
+      <h2 className={styles.h2}>講師</h2>
       <ul>
         <li>
           <Link
@@ -120,7 +120,7 @@ const AboutPage: NextPage = () => {
           </Link>
         </li>
       </ul>
-      <h2 className={h2}>インタビュー・寄稿</h2>
+      <h2 className={styles.h2}>インタビュー・寄稿</h2>
       <ul>
         <li>
           <Link

--- a/app/components/common/LinkCard/LinkCard.tsx
+++ b/app/components/common/LinkCard/LinkCard.tsx
@@ -1,14 +1,7 @@
 import type { FC } from "react";
 import type { EntryType } from "../../../types/EntryType";
 import Image from "next/image";
-import {
-  linkCard,
-  linkInner,
-  linkText,
-  linkUrl as linkUrlStyle,
-  ogImage,
-  ogTitle,
-} from "./LinkCard.css";
+import * as styles from "./LinkCard.css";
 import Link from "next/link";
 
 type Props = {
@@ -22,20 +15,27 @@ type Props = {
  */
 export const LinkCard: FC<Props> = ({ linkUrl, metaInfo }) => {
   return (
-    <Link className={linkCard} href={linkUrl} rel="noreferrer" target="_blank">
-      <span className={linkInner}>
+    <Link
+      className={styles.linkCard}
+      href={linkUrl}
+      rel="noreferrer"
+      target="_blank"
+    >
+      <span className={styles.linkInner}>
         {metaInfo?.ogImage && (
           <Image
-            className={ogImage}
+            className={styles.ogImage}
             src={metaInfo.ogImage}
             width="628"
             height="257"
             alt="entryData.ogInfo.title"
           />
         )}
-        {metaInfo?.ogTitle && <h4 className={ogTitle}>{metaInfo.ogTitle}</h4>}
-        <p className={linkUrlStyle}>
-          <span className={linkText}>{linkUrl}</span>
+        {metaInfo?.ogTitle && (
+          <h4 className={styles.ogTitle}>{metaInfo.ogTitle}</h4>
+        )}
+        <p className={styles.linkUrl}>
+          <span className={styles.linkText}>{linkUrl}</span>
         </p>
       </span>
     </Link>

--- a/app/components/common/MenuButton/MenuButton.tsx
+++ b/app/components/common/MenuButton/MenuButton.tsx
@@ -1,15 +1,6 @@
 import type { FC, HTMLAttributes } from "react";
 import clsx from "clsx";
-import {
-  border,
-  border1,
-  border1Closed,
-  border2,
-  border2Closed,
-  border3,
-  border3Closed,
-  menuButton,
-} from "./MenuButton.css";
+import * as styles from "./MenuButton.css";
 
 type Props = {
   /** ボタンが閉じられている見た目にするかどうか？ 閉じられている場合はバツ印になる */
@@ -23,11 +14,29 @@ type Props = {
 export const MenuButton: FC<Props> = ({ className, isClosed, onClick }) => (
   <button
     type="button"
-    className={clsx(className, menuButton)}
+    className={clsx(className, styles.menuButton)}
     onClick={onClick}
   >
-    <span className={clsx(border, border1, isClosed && border1Closed)} />
-    <span className={clsx(border, border2, isClosed && border2Closed)} />
-    <span className={clsx(border, border3, isClosed && border3Closed)} />
+    <span
+      className={clsx(
+        styles.border,
+        styles.border1,
+        isClosed && styles.border1Closed,
+      )}
+    />
+    <span
+      className={clsx(
+        styles.border,
+        styles.border2,
+        isClosed && styles.border2Closed,
+      )}
+    />
+    <span
+      className={clsx(
+        styles.border,
+        styles.border3,
+        isClosed && styles.border3Closed,
+      )}
+    />
   </button>
 );

--- a/app/components/concerns/Copyright/Copyright.tsx
+++ b/app/components/concerns/Copyright/Copyright.tsx
@@ -1,10 +1,10 @@
 import type { FC } from "react";
 
-import { copyright } from "./Copyright.css";
+import * as styles from "./Copyright.css";
 
 /**
  * コピーライト
  */
 export const Copyright: FC = () => (
-  <address className={copyright}>© 2023 Takeshi Kano</address>
+  <address className={styles.copyright}>© 2023 Takeshi Kano</address>
 );

--- a/app/components/concerns/EntryList/EntryList.tsx
+++ b/app/components/concerns/EntryList/EntryList.tsx
@@ -1,19 +1,7 @@
 import type { FC } from "react";
 import Link from "next/link";
 import type { EntryType } from "../../../types/EntryType";
-import {
-  entryList,
-  header,
-  info,
-  keyvisual,
-  link,
-  listTitle as listTitleStyle,
-  medium as mediumStyle,
-  publishedDate,
-  tag as tagStyle,
-  tagList,
-  title as titleStyle,
-} from "./EntryList.css";
+import * as styles from "./EntryList.css";
 import Image from "next/image";
 import { createHttpsImage } from "../../../utils";
 import { parseDate } from "../../../logics/date/parseDate";
@@ -25,8 +13,8 @@ type Props = {
 
 export const EntryList: FC<Props> = ({ listTitle, entryDataList }) => {
   return (
-    <div className={entryList}>
-      <h1 className={listTitleStyle}>{listTitle}</h1>
+    <div className={styles.entryList}>
+      <h1 className={styles.listTitle}>{listTitle}</h1>
       {entryDataList.map((entryData) => {
         const isWriting = entryData.medium?.slug === "writing";
 
@@ -46,33 +34,33 @@ export const EntryList: FC<Props> = ({ listTitle, entryDataList }) => {
             href={href}
             aria-label={entryData.title}
             target={target}
-            className={link}
+            className={styles.link}
           >
             {metaInfo?.ogImage && (
               <Image
-                className={keyvisual}
+                className={styles.keyvisual}
                 src={createHttpsImage(metaInfo.ogImage)}
                 alt={metaInfo.ogTitle ?? ""}
                 width={960}
                 height={540}
               />
             )}
-            <div className={info}>
-              <header className={header}>
-                <p className={mediumStyle}>{medium?.name}</p>
-                <ul className={tagList}>
+            <div className={styles.info}>
+              <header className={styles.header}>
+                <p className={styles.medium}>{medium?.name}</p>
+                <ul className={styles.tagList}>
                   {tags
                     ?.sort((a, b) => a.order - b.order)
                     .map(({ slug, name }) => (
-                      <li key={slug} className={tagStyle}>
+                      <li key={slug} className={styles.tag}>
                         #{name}
                       </li>
                     ))}
                 </ul>
               </header>
-              <h2 className={titleStyle}>{title}</h2>
+              <h2 className={styles.title}>{title}</h2>
               {published_date && (
-                <p className={publishedDate}>
+                <p className={styles.publishedDate}>
                   発表日
                   <time dateTime={published_date}>
                     {parseDate(published_date)}

--- a/app/components/concerns/Navigation/Navigation.tsx
+++ b/app/components/concerns/Navigation/Navigation.tsx
@@ -1,15 +1,7 @@
 import type { FC } from "react";
 import type { MediumType } from "../../../types/MediumType";
 import type { TagType } from "../../../types/TagType";
-import {
-  author,
-  container,
-  job,
-  navInner,
-  overlayNavigation,
-  profile,
-  sideNavigation,
-} from "./Navigation.css";
+import * as styles from "./Navigation.css";
 import Link from "next/link";
 import { SideNavigation } from "./SideNavigation";
 import { OverLayMenu } from "./OverLayMenu";
@@ -24,21 +16,21 @@ type Props = {
  */
 export const Navigation: FC<Props> = ({ mediumDataList, tagDataList }) => {
   return (
-    <nav className={container}>
-      <div className={navInner}>
+    <nav className={styles.container}>
+      <div className={styles.navInner}>
         <OverLayMenu
           mediumDataList={mediumDataList}
           tagDataList={tagDataList}
-          className={overlayNavigation}
+          className={styles.overlayNavigation}
         />
-        <div className={profile}>
-          <Link href="/" className={author}>
+        <div className={styles.profile}>
+          <Link href="/" className={styles.author}>
             Takeshi Kano
           </Link>
-          <p className={job}>Frontend Developer</p>
+          <p className={styles.job}>Frontend Developer</p>
         </div>
         <SideNavigation
-          className={sideNavigation}
+          className={styles.sideNavigation}
           mediumDataList={mediumDataList}
           tagDataList={tagDataList}
         />

--- a/app/components/concerns/Navigation/OverlayNavigation.tsx
+++ b/app/components/concerns/Navigation/OverlayNavigation.tsx
@@ -1,13 +1,6 @@
 import type { ForwardRefRenderFunction, HTMLAttributes, Ref } from "react";
 import { forwardRef } from "react";
-import {
-  category,
-  categoryHeading,
-  categoryList,
-  slug,
-  container,
-  menuButton,
-} from "./OverlayNavigation.css";
+import * as styles from "./OverlayNavigation.css";
 import Link from "next/link";
 import type { MediumType } from "../../../types/MediumType";
 import type { TagType } from "../../../types/TagType";
@@ -26,26 +19,26 @@ const _OverlayNavigation: ForwardRefRenderFunction<HTMLDialogElement, Props> = (
   { mediumDataList, tagDataList, onClickCloseButton, className, onChangePage },
   ref,
 ) => (
-  <dialog ref={ref} className={clsx(container, className)}>
+  <dialog ref={ref} className={clsx(styles.container, className)}>
     <MenuButton
-      className={menuButton}
+      className={styles.menuButton}
       onClick={onClickCloseButton}
       isClosed={true}
     />
-    <div className={category}>
-      <ul className={categoryList}>
+    <div className={styles.category}>
+      <ul className={styles.categoryList}>
         <li>
-          <Link href="/about" className={slug} onClick={onChangePage}>
+          <Link href="/about" className={styles.slug} onClick={onChangePage}>
             自己紹介
           </Link>
         </li>
       </ul>
     </div>
-    <div className={category}>
-      <h2 className={categoryHeading}>カテゴリ</h2>
-      <ul className={categoryList}>
+    <div className={styles.category}>
+      <h2 className={styles.categoryHeading}>カテゴリ</h2>
+      <ul className={styles.categoryList}>
         <li>
-          <Link href="/" className={slug} onClick={onChangePage}>
+          <Link href="/" className={styles.slug} onClick={onChangePage}>
             すべての実績
           </Link>
         </li>
@@ -53,7 +46,7 @@ const _OverlayNavigation: ForwardRefRenderFunction<HTMLDialogElement, Props> = (
           <li key={slugData}>
             <Link
               href={`/medium/${slugData}`}
-              className={slug}
+              className={styles.slug}
               onClick={onChangePage}
             >
               {name}
@@ -62,14 +55,14 @@ const _OverlayNavigation: ForwardRefRenderFunction<HTMLDialogElement, Props> = (
         ))}
       </ul>
     </div>
-    <div className={category}>
-      <h2 className={categoryHeading}>タグ</h2>
-      <ul className={categoryList}>
+    <div className={styles.category}>
+      <h2 className={styles.categoryHeading}>タグ</h2>
+      <ul className={styles.categoryList}>
         {tagDataList.map(({ name, slug: slugData }) => (
           <li key={slugData}>
             <Link
               href={`/tag/${slugData}`}
-              className={slug}
+              className={styles.slug}
               onClick={onChangePage}
             >
               #{name}

--- a/app/components/concerns/Navigation/SideNavigation.tsx
+++ b/app/components/concerns/Navigation/SideNavigation.tsx
@@ -1,15 +1,11 @@
 import type { FC, HTMLAttributes } from "react";
-import {
-  category,
-  categoryHeading,
-  categoryList,
-  container,
-} from "./SideNavigation.css";
+
+import * as styles from "./SideNavigation.css";
+import * as navigationStyles from "./Navigation.css";
 
 import Link from "next/link";
 import type { MediumType } from "../../../types/MediumType";
 import type { TagType } from "../../../types/TagType";
-import { slug } from "./Navigation.css";
 import clsx from "clsx";
 
 type Props = {
@@ -23,39 +19,42 @@ export const SideNavigation: FC<Props> = ({
   className,
 }) => {
   return (
-    <div className={clsx(container, className)}>
-      <div className={category}>
-        <ul className={categoryList}>
+    <div className={clsx(styles.container, className)}>
+      <div className={styles.category}>
+        <ul className={styles.categoryList}>
           <li>
-            <Link href="/about" className={slug}>
+            <Link href="/about" className={navigationStyles.slug}>
               自己紹介
             </Link>
           </li>
         </ul>
       </div>
-      <div className={category}>
-        <h2 className={categoryHeading}>カテゴリ</h2>
-        <ul className={categoryList}>
+      <div className={styles.category}>
+        <h2 className={styles.categoryHeading}>カテゴリ</h2>
+        <ul className={styles.categoryList}>
           <li>
-            <Link href="/" className={slug}>
+            <Link href="/" className={navigationStyles.slug}>
               すべての実績
             </Link>
           </li>
           {mediumDataList.map(({ name, slug: slugData }) => (
             <li key={slugData}>
-              <Link href={`/medium/${slugData}`} className={slug}>
+              <Link
+                href={`/medium/${slugData}`}
+                className={navigationStyles.slug}
+              >
                 {name}
               </Link>
             </li>
           ))}
         </ul>
       </div>
-      <div className={category}>
-        <h2 className={categoryHeading}>タグ</h2>
-        <ul className={categoryList}>
+      <div className={styles.category}>
+        <h2 className={styles.categoryHeading}>タグ</h2>
+        <ul className={styles.categoryList}>
           {tagDataList.map(({ name, slug: slugData }) => (
             <li key={slugData}>
-              <Link href={`/tag/${slugData}`} className={slug}>
+              <Link href={`/tag/${slugData}`} className={navigationStyles.slug}>
                 #{name}
               </Link>
             </li>

--- a/app/entry/[slug]/page.tsx
+++ b/app/entry/[slug]/page.tsx
@@ -3,17 +3,7 @@ import {
   fetchAllEntryData,
   fetchEntryData,
 } from "../../logics/api/fetchAllEntryData";
-import {
-  article,
-  container,
-  header,
-  medium as mediumStyle,
-  publishedDate,
-  tag as tagStyle,
-  tagList,
-  title as titleStyle,
-  video,
-} from "./page.css";
+import * as styles from "./page.css";
 import { Copyright } from "../../components/concerns/Copyright";
 import { DetailHTML } from "../../components/concerns/DetailHTML/DetailHTML";
 import { LinkCard } from "../../components/common/LinkCard";
@@ -70,23 +60,23 @@ const Page: NextPage<Params> = async ({ params }) => {
   await getMetaDataForEntryDataList([entryData]);
 
   return (
-    <div className={container}>
-      <article className={article}>
-        <header className={header}>
-          <p className={mediumStyle}>{entryData.medium?.name}</p>
-          <ul className={tagList}>
+    <div className={styles.container}>
+      <article className={styles.article}>
+        <header className={styles.header}>
+          <p className={styles.medium}>{entryData.medium?.name}</p>
+          <ul className={styles.tagList}>
             {entryData.tags
               ?.sort((a, b) => a.order - b.order)
               .map(({ slug, name }) => (
-                <li key={slug} className={tagStyle}>
+                <li key={slug} className={styles.tag}>
                   #{name}
                 </li>
               ))}
           </ul>
         </header>
-        <h2 className={titleStyle}>{entryData.title}</h2>
+        <h2 className={styles.title}>{entryData.title}</h2>
         {entryData.published_date && (
-          <p className={publishedDate}>
+          <p className={styles.publishedDate}>
             発表日
             <time dateTime={entryData.published_date}>
               {parseDate(entryData.published_date)}
@@ -97,7 +87,7 @@ const Page: NextPage<Params> = async ({ params }) => {
         {/* ビデオ */}
         {entryData.videoUrl && (
           <iframe
-            className={video}
+            className={styles.video}
             width="560"
             height="315"
             src={entryData.videoUrl}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,7 +11,7 @@ import type { TagType } from "./types/TagType";
 import { fetchMedia } from "./logics/api/fetchMedia";
 import { fetchTagList } from "./logics/api/fetchTagList";
 import type { Metadata, NextPage } from "next";
-import { main, root, wrapper } from "./layout.css";
+import * as styles from "./layout.css";
 import "./styles/reset.css";
 import "./styles/base.css";
 import { GoogleAnalytics } from "./components/common/GoogleAnalytics";
@@ -55,13 +55,13 @@ const RootLayout: NextPage<{ children: ReactNode }> = async ({ children }) => {
         <link rel="apple-touch-icon" href="/apple-icon.png" />
       </head>
       <body>
-        <div className={root}>
-          <div className={wrapper}>
+        <div className={styles.root}>
+          <div className={styles.wrapper}>
             <Navigation
               mediumDataList={mediumDataList}
               tagDataList={tagDataList}
             />
-            <main className={main}>{children}</main>
+            <main className={styles.main}>{children}</main>
           </div>
         </div>
         <GoogleAnalytics />

--- a/app/medium/[slug]/page.tsx
+++ b/app/medium/[slug]/page.tsx
@@ -2,7 +2,7 @@ import type { NextPage, Metadata } from "next";
 
 import { EntryList } from "../../components/concerns/EntryList";
 import { fetchAllEntryData } from "../../logics/api/fetchAllEntryData";
-import { container } from "./page.css";
+import * as styles from "./page.css";
 import { Copyright } from "../../components/concerns/Copyright";
 import { fetchMedia } from "../../logics/api/fetchMedia";
 import { WithSiteTitle } from "../../constants";
@@ -56,7 +56,7 @@ const Page: NextPage<Params> = async ({ params }) => {
   await getMetaDataForEntryDataList(entryDataList, 12);
 
   return (
-    <div className={container}>
+    <div className={styles.container}>
       <EntryList
         listTitle={entryDataList[0]?.medium?.name ?? ""}
         entryDataList={entryDataList}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@ import type { EntryType } from "./types/EntryType";
 import { EntryList } from "./components/concerns/EntryList";
 import { fetchAllEntryData } from "./logics/api/fetchAllEntryData";
 import { Copyright } from "./components/concerns/Copyright";
-import { container } from "./page.css";
+import * as styles from "./page.css";
 import { getMetaDataForEntryDataList } from "./logics/scraping/getMetaDataForEntryDataList";
 
 const getEntryData = async (): Promise<{
@@ -20,7 +20,7 @@ const Page: NextPage = async () => {
   await getMetaDataForEntryDataList(entryDataList);
 
   return (
-    <div className={container}>
+    <div className={styles.container}>
       <EntryList listTitle="すべての実績" entryDataList={entryDataList} />
       <Copyright />
     </div>

--- a/app/tag/[slug]/page.tsx
+++ b/app/tag/[slug]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata, NextPage } from "next";
 
 import { EntryList } from "../../components/concerns/EntryList";
 import { fetchAllEntryData } from "../../logics/api/fetchAllEntryData";
-import { container } from "./page.css";
+import * as styles from "./page.css";
 import { Copyright } from "../../components/concerns/Copyright";
 import { fetchTagList } from "../../logics/api/fetchTagList";
 import { metadata } from "../../layout";
@@ -59,7 +59,7 @@ const Page: NextPage<Params> = async ({ params }) => {
   await getMetaDataForEntryDataList(entryDataList, 12);
 
   return (
-    <div className={container}>
+    <div className={styles.container}>
       <EntryList listTitle={tagTitle} entryDataList={entryDataList} />
       <Copyright />
     </div>


### PR DESCRIPTION
This commit refactors the way CSS imports were handled in multiple components. Instead of individually importing specific styles from the CSS modules, all styles are now imported at once using a wildcard import statement (* as styles). This makes the code cleaner and easier to manage by reducing the number of import lines. It also improves consistency in style handling across the components.
<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:
- Refactor: The code has been refactored to use wildcard import statements for CSS styles in multiple components, resulting in cleaner code, improved consistency, and enhanced maintainability.

> "Code refactored with care,
> Wildcard imports everywhere.
> Clean and consistent, it's a delight,
> Improved codebase shining bright."
<!-- end of auto-generated comment: release notes by openai -->