### PR TITLE
Add padding-top to SideNavigation container

### DIFF
--- a/app/components/concerns/Navigation/SideNavigation.css.ts
+++ b/app/components/concerns/Navigation/SideNavigation.css.ts
@@ -5,6 +5,7 @@ import { vars } from "../../../styles/vars.css";
 export const container = style({
   display: "grid",
   gap: vars.spacing["32px"],
+  paddingTop: vars.spacing["32px"],
 });
 
 export const category = style({


### PR DESCRIPTION
In the SideNavigation.css.ts file, a paddingTop property was added to the container styling. This change was made to maintain consistency in design and improve the overall aesthetic appeal of the navigation side bar.
<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:
- Style: Added `paddingTop` property to the `container` styling in `SideNavigation.css.ts` for improved aesthetic appeal of the navigation sidebar.

> "A touch of padding, a visual delight,
> Side navigation shines, oh so bright.
> Consistency maintained, aesthetics refined,
> With this PR, the UI is truly aligned."
<!-- end of auto-generated comment: release notes by openai -->