### PR TITLE
Remove unuseless div in EntryCard

### DIFF
--- a/app/components/common/LinkCard/LinkCard.css.ts
+++ b/app/components/common/LinkCard/LinkCard.css.ts
@@ -14,10 +14,11 @@ export const linkInner = style({
   display: "grid",
   overflow: "hidden",
   gridTemplate: `
-      "thumbs" auto
-      "title"  auto
-      "url"  auto / 
-      1fr`,
+      "thumbs thumbs thumbs" auto
+      ". . . "  0
+      ". title ."  auto
+      ". url ."  auto / 
+      ${vars.spacing["16px"]} 1fr ${vars.spacing["16px"]}`,
   background: "#ffffff",
   border: "1px solid rgba(48, 55, 120, 0.2)",
   borderRadius: "14px",
@@ -64,7 +65,6 @@ export const ogTitle = style({
   // @ts-expect-error
   webkitBoxOrient: "vertical",
   webkitLineClamp: "2",
-  paddingInline: vars.spacing["16px"],
   lineHeight: "1.4",
   "@container": {
     "(500px < width)": {
@@ -85,7 +85,6 @@ export const linkUrl = style({
   alignItems: "center",
   fontSize: vars.font.size.s,
   alignSelf: "start",
-  paddingInline: vars.spacing["16px"],
   "@container": {
     "(500px < width)": {
       paddingInline: 0,

--- a/app/components/concerns/EntryList/EntryList.css.ts
+++ b/app/components/concerns/EntryList/EntryList.css.ts
@@ -1,4 +1,4 @@
-import { style } from "@vanilla-extract/css";
+import { globalStyle, style } from "@vanilla-extract/css";
 
 import { vars } from "../../../styles/vars.css";
 
@@ -14,18 +14,20 @@ export const listTitle = style({
 });
 
 export const link = style({
-  display: "block",
+  display: "grid",
   overflow: "hidden",
   background: "#ffffff",
   border: "1px solid #f1f3fa",
+  gap: vars.spacing["8px"],
   borderRadius: "14px",
   boxShadow: "2px 8px 30px rgba(48, 55, 120, 0.04)",
+  gridTemplateColumns: `[main-start] ${vars.spacing["8px"]} [content-start] 1fr [content-end] ${vars.spacing["8px"]} [main-end]`,
+  justifyContent: "center",
+  paddingBottom: vars.spacing["16px"],
 });
 
-export const info = style({
-  display: "grid",
-  gap: vars.spacing["8px"],
-  padding: vars.spacing["16px"],
+globalStyle(`${link} *`, {
+  gridColumn: "content",
 });
 
 export const keyvisual = style({
@@ -33,11 +35,13 @@ export const keyvisual = style({
   width: "100%",
   height: "auto",
   aspectRatio: "16/7",
+  gridColumn: "main",
 });
 
 export const header = style({
   display: "flex",
   alignItems: "center",
+  marginTop: vars.spacing["8px"],
 });
 
 export const medium = style({

--- a/app/components/concerns/EntryList/EntryList.stories.tsx
+++ b/app/components/concerns/EntryList/EntryList.stories.tsx
@@ -1,0 +1,42 @@
+import { EntryList } from "./EntryList";
+
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta = {
+  component: EntryList,
+  args: {
+    listTitle: "タイトル",
+    entryDataList: [...new Array(5)].map((_, index) => {
+      return {
+        id: `${index + 1}`,
+        medium: {
+          slug: "writing",
+          name: "Medium名",
+        },
+        metaInfo: {
+          ogImage: "https://picsum.photos/id/13/200/300",
+          ogTitle: "リンクタイトル",
+          ogDescription: "説明",
+        },
+
+        published_date: "2023-12-12",
+        slug: "writing",
+        tags: [
+          {
+            id: "2",
+            name: "タグ名",
+            order: 0,
+            slug: "my-tag",
+          },
+        ],
+        title: `記事タイトル${index + 1}`,
+        url: "https://example.com",
+      };
+    }),
+  },
+} satisfies Meta<typeof EntryList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/app/components/concerns/EntryList/EntryList.tsx
+++ b/app/components/concerns/EntryList/EntryList.tsx
@@ -48,29 +48,27 @@ export const EntryList: FC<Props> = ({ listTitle, entryDataList }) => {
                 height={540}
               />
             )}
-            <div className={styles.info}>
-              <header className={styles.header}>
-                <p className={styles.medium}>{medium?.name}</p>
-                <ul className={styles.tagList}>
-                  {tags
-                    ?.sort((a, b) => a.order - b.order)
-                    .map(({ slug, name }) => (
-                      <li key={slug} className={styles.tag}>
-                        #{name}
-                      </li>
-                    ))}
-                </ul>
-              </header>
-              <h2 className={styles.title}>{title}</h2>
-              {published_date != null && (
-                <p className={styles.publishedDate}>
-                  発表日
-                  <time dateTime={published_date}>
-                    {parseDate(published_date)}
-                  </time>
-                </p>
-              )}
-            </div>
+            <header className={styles.header}>
+              <p className={styles.medium}>{medium?.name}</p>
+              <ul className={styles.tagList}>
+                {tags
+                  ?.sort((a, b) => a.order - b.order)
+                  .map(({ slug, name }) => (
+                    <li key={slug} className={styles.tag}>
+                      #{name}
+                    </li>
+                  ))}
+              </ul>
+            </header>
+            <h2 className={styles.title}>{title}</h2>
+            {published_date != null && (
+              <p className={styles.publishedDate}>
+                発表日
+                <time dateTime={published_date}>
+                  {parseDate(published_date)}
+                </time>
+              </p>
+            )}
           </Link>
         );
       })}


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:

- Style: Modified the `gridTemplate` property in the `linkInner` style of `LinkCard.css.ts` to adjust grid layout and element positioning. Removed `paddingInline` property from `ogTitle` and `linkUrl` styles.
- Style: Added an import statement for `globalStyle` from `@vanilla-extract/css` library in `EntryList.css.ts`. Updated `link` style with grid display property and added global style rule for descendants of `link` class.
- New Feature: Added `EntryList.stories.tsx` file exporting default metadata and story object for `EntryList` component, allowing easy population of dummy data.
- Refactor: Restructured code in `EntryList.tsx` to remove unnecessary nesting and moved contents outside of a `<div>` element.

> "Code changes dance,
> Styles gracefully enhance.
> Stories unfold,
> Nesting's grip, we behold.
> Release notes sing,
> Progress, it does bring."
<!-- end of auto-generated comment: release notes by openai -->