### PR TITLE
feat: Add new and reposition existing links in about page

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -42,6 +42,11 @@ const AboutPage: NextPage = () => {
       <h2 className={styles.h2}>書籍</h2>
       <ul className={styles.list}>
         <li>
+          <Link href="https://gihyo.jp/book/2019/978-4-297-10368-2" target="_blank">
+            JavaScriptコードレシピ集
+          </Link>
+        </li>
+        <li>
           <Link
             href="https://info.nikkeibp.co.jp/media/NSW/atcl/mag/051600042/"
             target="_blank"
@@ -65,11 +70,7 @@ const AboutPage: NextPage = () => {
             日経ソフトウェア2020年9月号「JavaScript最新仕様 -ECMAScript2020-」
           </Link>
         </li>
-        <li>
-          <Link href="https://ics.media/entry/19765/" target="_blank">
-            JavaScriptコードレシピ集
-          </Link>
-        </li>
+
       </ul>
       <h2 className={styles.h2}>技術発信</h2>
       <ul>
@@ -127,10 +128,19 @@ const AboutPage: NextPage = () => {
       <ul>
         <li>
           <Link
+            href="https://levtech.jp/media/article/column/detail_329/"
+            target="_blank"
+          >
+            アウトプットこそ最高のインプット。鹿野壮が語る「自分が一番トクする」アウトプットの力
+            - レバテックラボ
+          </Link>
+        </li>
+        <li>
+          <Link
             href="https://findy-code.io/engineer-lab/tonkotsuboy-output"
             target="_blank"
           >
-            術発信していますか？アウトプットをするのが嫌だったソフトウェアエンジニアが登壇中毒になるまでの話
+            技術発信していますか？アウトプットをするのが嫌だったソフトウェアエンジニアが登壇中毒になるまでの話
             - Findy Engineer Lab
           </Link>
         </li>


### PR DESCRIPTION
Added a new link to a book in the Books section and adjusted the existing link's position in the same section. Also, a new link is added to the Interview section. This is done to maintain the information's relevance and provide up-to-date resource references.
<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:
- New Feature: Added a new link to a book in the "Books" section of the About page.
- Enhancement: Adjusted the position of an existing link in the "Books" section.
- New Feature: Added a new link to the "Interview" section of the About page.

> "A tale of links, both old and new,
> The About page shines with a different hue.
> Books and interviews, now intertwined,
> A code change that leaves us all aligned."
<!-- end of auto-generated comment: release notes by openai -->