### PR TITLE
fix: Add gap and modify display style in page and EntryList css files

### DIFF
--- a/app/components/concerns/EntryList/EntryList.css.ts
+++ b/app/components/concerns/EntryList/EntryList.css.ts
@@ -57,9 +57,8 @@ export const medium = style({
 });
 
 export const tagList = style({
-  display: "grid",
-  gridAutoFlow: "column",
-  gap: "6px",
+  display: "flex",
+  gap: vars.spacing["8px"],
   height: "100%",
 });
 

--- a/app/entry/[slug]/page.css.ts
+++ b/app/entry/[slug]/page.css.ts
@@ -26,6 +26,7 @@ export const article = style({
 export const header = style({
   display: "flex",
   alignItems: "center",
+  gap: vars.spacing["8px"],
 });
 
 export const medium = style({


### PR DESCRIPTION
Gap has been added to the header style in the page CSS file, providing improved spacing. In the EntryList CSS file, the tagList's display style has been changed from 'grid' to 'flex' for better alignment. Gap size has also been standardized across both files for uniformity.
<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:
- Style: Improved spacing and alignment in CSS styles for `EntryList` component and entry page.
- Style: Added `gap` property to the `header` style and changed `display` style of `tagList` from `'grid'` to `'flex'`.
- Style: Standardized gap size across files.

> "In a world of pixels, where style reigns supreme,
> We bring harmony and balance, like a dream.
> Spacing and alignment, we refine with care,
> CSS changes that make visuals fair.
> With grids and flex, we dance in delight,
> Creating layouts that are a pure delight."
<!-- end of auto-generated comment: release notes by openai -->