### PR TITLE
feat: add Claude CI Auto Fix workflow

### DIFF
--- a/.github/workflows/claude-ci-auto-fix.yml
+++ b/.github/workflows/claude-ci-auto-fix.yml
@@ -122,8 +122,13 @@ jobs:
 
             ## 修正手順
             1. エラーログを読んで原因を特定する
-            2. 必要なファイルを修正する（lint エラーなら `pnpm lint:next:fix` や `pnpm lint:css:fix` も活用）
-            3. `pnpm install --frozen-lockfile` でセットアップ後、`pnpm velite build` で型定義を生成する
+            2. `pnpm install --frozen-lockfile` で依存関係をインストールする
+            3. `pnpm velite build` で型定義（`.velite/`）を生成する
+            4. 必要なファイルを修正する（lint エラーなら `pnpm lint:next:fix` や `pnpm lint:css:fix` も活用）
+            5. ローカルでエラーが解消されているか確認する
+            6. 修正内容を git commit する
+            7. `git push origin <修正用ブランチ名>` でブランチをプッシュする
+            8. `gh pr create --base <元のブランチ名> --head <修正用ブランチ名>` で元のフィーチャーブランチへのfixのPRを作成する（タイトルは英語、本文は日本語）
             4. ローカルでエラーが解消されているか確認する
             5. 修正内容を git commit する
             6. `git push origin <修正用ブランチ名>` でブランチをプッシュする

--- a/.github/workflows/claude-ci-auto-fix.yml
+++ b/.github/workflows/claude-ci-auto-fix.yml
@@ -123,6 +123,8 @@ jobs:
             ## 修正手順
             1. エラーログを読んで原因を特定する
             2. 必要なファイルを修正する（lint エラーなら `pnpm lint:next:fix` や `pnpm lint:css:fix` も活用）
-            3. `pnpm install --frozen-lockfile` でセットアップ後、ローカルでエラーが解消されているか確認
-            4. 修正内容を git commit する
-            5. `gh pr create --base <元のブランチ名>` で元のフィーチャーブランチへのfixのPRを作成する（タイトルは英語、本文は日本語）
+            3. `pnpm install --frozen-lockfile` でセットアップ後、`pnpm velite build` で型定義を生成する
+            4. ローカルでエラーが解消されているか確認する
+            5. 修正内容を git commit する
+            6. `git push origin <修正用ブランチ名>` でブランチをプッシュする
+            7. `gh pr create --base <元のブランチ名> --head <修正用ブランチ名>` で元のフィーチャーブランチへのfixのPRを作成する（タイトルは英語、本文は日本語）

--- a/.github/workflows/claude-ci-auto-fix.yml
+++ b/.github/workflows/claude-ci-auto-fix.yml
@@ -13,16 +13,17 @@ permissions:
   pull-requests: write
   actions: read
   issues: write
-  id-token: write
 
 jobs:
   auto-fix:
     # PR上のCIが失敗した場合のみ実行（mainへのpushは除外）
     # claude-auto-fix-ci-* ブランチ自体が失敗した場合は無限ループを防ぐためスキップ
+    # Dependabot PR はスキップ
     if: |
       github.event.workflow_run.conclusion == 'failure' &&
       github.event.workflow_run.pull_requests[0] &&
-      !startsWith(github.event.workflow_run.head_branch, 'claude-auto-fix-ci-')
+      !startsWith(github.event.workflow_run.head_branch, 'claude-auto-fix-ci-') &&
+      github.event.workflow_run.actor.login != 'dependabot[bot]'
 
     runs-on: ubuntu-latest
 
@@ -44,7 +45,8 @@ jobs:
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
           RUN_ID: ${{ github.run_id }}
         run: |
-          BRANCH_NAME="claude-auto-fix-ci-${HEAD_BRANCH}-${RUN_ID}"
+          SAFE_BRANCH=$(echo "${HEAD_BRANCH}" | tr '/' '-')
+          BRANCH_NAME="claude-auto-fix-ci-${SAFE_BRANCH}-${RUN_ID}"
           git checkout -b "$BRANCH_NAME"
           echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
 
@@ -70,7 +72,11 @@ jobs:
                   repo: context.repo.repo,
                   job_id: job.id
                 });
-                errorLogs.push({ jobName: job.name, logs: logs.data.slice(-5000) });
+                const logText = logs.data;
+                const truncated = logText.length > 10000
+                  ? logText.slice(0, 3000) + '\n...(省略)...\n' + logText.slice(-7000)
+                  : logText;
+                errorLogs.push({ jobName: job.name, logs: truncated });
               } catch (e) {
                 errorLogs.push({ jobName: job.name, logs: '(ログ取得失敗)' });
               }

--- a/.github/workflows/claude-ci-auto-fix.yml
+++ b/.github/workflows/claude-ci-auto-fix.yml
@@ -60,6 +60,12 @@ jobs:
           node-version-file: ".node-version"
           cache: "pnpm"
 
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Velite content
+        run: pnpm velite build
+
       - name: Get CI failure details
         id: failure_details
         uses: actions/github-script@v7
@@ -129,7 +135,3 @@ jobs:
             6. 修正内容を git commit する
             7. `git push origin <修正用ブランチ名>` でブランチをプッシュする
             8. `gh pr create --base <元のブランチ名> --head <修正用ブランチ名>` で元のフィーチャーブランチへのfixのPRを作成する（タイトルは英語、本文は日本語）
-            4. ローカルでエラーが解消されているか確認する
-            5. 修正内容を git commit する
-            6. `git push origin <修正用ブランチ名>` でブランチをプッシュする
-            7. `gh pr create --base <元のブランチ名> --head <修正用ブランチ名>` で元のフィーチャーブランチへのfixのPRを作成する（タイトルは英語、本文は日本語）

--- a/.github/workflows/claude-ci-auto-fix.yml
+++ b/.github/workflows/claude-ci-auto-fix.yml
@@ -23,7 +23,8 @@ jobs:
       github.event.workflow_run.conclusion == 'failure' &&
       github.event.workflow_run.pull_requests[0] &&
       !startsWith(github.event.workflow_run.head_branch, 'claude-auto-fix-ci-') &&
-      github.event.workflow_run.actor.login != 'dependabot[bot]'
+      github.event.workflow_run.actor.login != 'dependabot[bot]' &&
+      github.event.workflow_run.actor.login == 'tonkotsuboy'
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/claude-ci-auto-fix.yml
+++ b/.github/workflows/claude-ci-auto-fix.yml
@@ -1,0 +1,110 @@
+name: Claude CI Auto Fix
+
+# Lint または Test が失敗したとき、Claude が自動でfixしてPRを作る
+
+on:
+  workflow_run:
+    workflows: ["Lint", "Test"]
+    types:
+      - completed
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+  issues: write
+  id-token: write
+
+jobs:
+  auto-fix:
+    # PR上のCIが失敗した場合のみ実行（mainへのpushは除外）
+    # claude-auto-fix-ci-* ブランチ自体が失敗した場合は無限ループを防ぐためスキップ
+    if: |
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.pull_requests[0] &&
+      !startsWith(github.event.workflow_run.head_branch, 'claude-auto-fix-ci-')
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
+          fetch-depth: 0
+
+      - name: Setup git identity
+        run: |
+          git config --global user.email "claude[bot]@users.noreply.github.com"
+          git config --global user.name "claude[bot]"
+
+      - name: Create fix branch
+        id: branch
+        env:
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          BRANCH_NAME="claude-auto-fix-ci-${HEAD_BRANCH}-${RUN_ID}"
+          git checkout -b "$BRANCH_NAME"
+          echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Get CI failure details
+        id: failure_details
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const workflowRun = context.payload.workflow_run;
+            const jobs = await github.rest.actions.listJobsForWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: workflowRun.id
+            });
+
+            const failedJobs = jobs.data.jobs.filter(job => job.conclusion === 'failure');
+
+            let errorLogs = [];
+            for (const job of failedJobs) {
+              try {
+                const logs = await github.rest.actions.downloadJobLogsForWorkflowRun({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  job_id: job.id
+                });
+                errorLogs.push({ jobName: job.name, logs: logs.data.slice(-5000) });
+              } catch (e) {
+                errorLogs.push({ jobName: job.name, logs: '(ログ取得失敗)' });
+              }
+            }
+
+            return {
+              runUrl: workflowRun.html_url,
+              workflowName: workflowRun.name,
+              failedJobNames: failedJobs.map(j => j.name).join(', '),
+              prNumber: workflowRun.pull_requests[0]?.number ?? '',
+              errorLogs
+            };
+
+      - name: Fix CI failures with Claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: >-
+            --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git:*),Bash(pnpm:*),Bash(npx:*),Bash(gh:*)"
+          prompt: |
+            以下のCIが失敗しています。エラーを解析して修正し、コミット後にPRを作成してください。
+
+            ワークフロー: ${{ fromJSON(steps.failure_details.outputs.result).workflowName }}
+            失敗したジョブ: ${{ fromJSON(steps.failure_details.outputs.result).failedJobNames }}
+            失敗したCIのURL: ${{ fromJSON(steps.failure_details.outputs.result).runUrl }}
+            修正用ブランチ: ${{ steps.branch.outputs.branch_name }}
+            元のPR番号: ${{ fromJSON(steps.failure_details.outputs.result).prNumber }}
+
+            エラーログ:
+            ${{ toJSON(fromJSON(steps.failure_details.outputs.result).errorLogs) }}
+
+            ## 修正手順
+            1. エラーログを読んで原因を特定する
+            2. 必要なファイルを修正する（lint エラーなら `pnpm lint:next:fix` や `pnpm lint:css:fix` も活用）
+            3. `pnpm install --frozen-lockfile` でセットアップ後、ローカルでエラーが解消されているか確認
+            4. 修正内容を git commit する
+            5. `gh pr create` で元のPRへのfixのPRを作成する（タイトルは英語、本文は日本語）

--- a/.github/workflows/claude-ci-auto-fix.yml
+++ b/.github/workflows/claude-ci-auto-fix.yml
@@ -12,13 +12,13 @@ permissions:
   contents: write
   pull-requests: write
   actions: read
-  issues: write
 
 jobs:
   auto-fix:
     # PR上のCIが失敗した場合のみ実行（mainへのpushは除外）
     # claude-auto-fix-ci-* ブランチ自体が失敗した場合は無限ループを防ぐためスキップ
     # Dependabot PR はスキップ
+    # リポジトリオーナー以外のPR（フォークPR等）はスキップ
     if: |
       github.event.workflow_run.conclusion == 'failure' &&
       github.event.workflow_run.pull_requests[0] &&
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_branch }}
+          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
 
       - name: Setup git identity
@@ -44,12 +44,21 @@ jobs:
         id: branch
         env:
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
-          RUN_ID: ${{ github.run_id }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
         run: |
           SAFE_BRANCH=$(echo "${HEAD_BRANCH}" | tr '/' '-')
           BRANCH_NAME="claude-auto-fix-ci-${SAFE_BRANCH}-${RUN_ID}"
           git checkout -b "$BRANCH_NAME"
           echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".node-version"
+          cache: "pnpm"
 
       - name: Get CI failure details
         id: failure_details
@@ -87,6 +96,7 @@ jobs:
               runUrl: workflowRun.html_url,
               workflowName: workflowRun.name,
               failedJobNames: failedJobs.map(j => j.name).join(', '),
+              headBranch: workflowRun.head_branch,
               prNumber: workflowRun.pull_requests[0]?.number ?? '',
               errorLogs
             };
@@ -104,6 +114,7 @@ jobs:
             失敗したジョブ: ${{ fromJSON(steps.failure_details.outputs.result).failedJobNames }}
             失敗したCIのURL: ${{ fromJSON(steps.failure_details.outputs.result).runUrl }}
             修正用ブランチ: ${{ steps.branch.outputs.branch_name }}
+            元のブランチ名: ${{ fromJSON(steps.failure_details.outputs.result).headBranch }}
             元のPR番号: ${{ fromJSON(steps.failure_details.outputs.result).prNumber }}
 
             エラーログ:
@@ -114,4 +125,4 @@ jobs:
             2. 必要なファイルを修正する（lint エラーなら `pnpm lint:next:fix` や `pnpm lint:css:fix` も活用）
             3. `pnpm install --frozen-lockfile` でセットアップ後、ローカルでエラーが解消されているか確認
             4. 修正内容を git commit する
-            5. `gh pr create` で元のPRへのfixのPRを作成する（タイトルは英語、本文は日本語）
+            5. `gh pr create --base <元のブランチ名>` で元のフィーチャーブランチへのfixのPRを作成する（タイトルは英語、本文は日本語）


### PR DESCRIPTION
## 概要

Lint または Test の CI が PR 上で失敗したとき、Claude が自動でエラーを解析・修正してfixのPRを作成するワークフローを追加。

## 動作フロー

1. `Lint` または `Test` ワークフローが失敗
2. 失敗したジョブのログを取得
3. `claude-auto-fix-ci-{ブランチ名}-{run_id}` という修正用ブランチを作成
4. Claude がエラーログを分析して修正（`pnpm lint:next:fix` や `pnpm lint:css:fix` も活用）
5. 元のPRに対してfixのPRを自動作成

## 無限ループ対策

- `claude-auto-fix-ci-*` ブランチ自体が失敗しても再実行しない
- Dependabot PR は対象外

🤖 Generated with [Claude Code](https://claude.com/claude-code)