### PR TITLE
fix: AboutページのJS/TS書籍リンクをgihyo.jpに更新

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -61,7 +61,7 @@ const socialLinks = [
 const publications = [
   {
     cover: "/images/books/js-ts-jitsuryoku.png",
-    href: "https://www.amazon.co.jp/dp/B0FQ13X48L",
+    href: "https://gihyo.jp/book/2025/978-4-297-15194-2",
     publisher: "技術評論社",
     title: "JavaScript & TypeScript実力強化書",
   },


### PR DESCRIPTION
## 変更概要

AboutページのJavaScript & TypeScript実力強化書のリンク先をAmazonから技術評論社（gihyo.jp）に変更。

## 変更点

- `app/about/page.tsx`: 書籍リンクを `https://www.amazon.co.jp/dp/B0FQ13X48L` → `https://gihyo.jp/book/2025/978-4-297-15194-2` に更新