### PR TITLE
fix: 未使用のスキップナビゲーションを削除

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -117,7 +117,7 @@ const AboutPage: NextPage = () => {
   return (
     <div className={styles.shell}>
       <Header />
-      <main id="main-content" className={styles.main}>
+      <main className={styles.main}>
         <div className={styles.page}>
           {/* Profile Hero */}
           <div className={styles.profileHero}>

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -62,7 +62,7 @@ const ContactPage: NextPage = () => {
   return (
     <div className={styles.shell}>
       <Header />
-      <main id="main-content" className={styles.main}>
+      <main className={styles.main}>
         <div className={styles.page}>
           <div className={styles.hero}>
             <h1 className={styles.title}>Contact</h1>

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -12,7 +12,7 @@ export default function ErrorPage({
   return (
     <div className={styles.shell}>
       <Header />
-      <main id="main-content" className={styles.main}>
+      <main className={styles.main}>
         <div className={styles.page}>
           <p className={styles.code}>Error</p>
           <h1 className={styles.title}>問題が発生しました</h1>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -85,9 +85,6 @@ export default function RootLayout({
   return (
     <html lang="ja" className={clsx(inter.variable, notoSansJP.variable)} suppressHydrationWarning>
       <body>
-        <a href="#main-content" className="skip-nav">
-          メインコンテンツへスキップ
-        </a>
         <ThemeProvider>{children}</ThemeProvider>
         <ServiceWorkerRegister />
       </body>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -14,7 +14,7 @@ export default function NotFound() {
   return (
     <div className={styles.shell}>
       <Header />
-      <main id="main-content" className={styles.main}>
+      <main className={styles.main}>
         <div className={styles.page}>
           <p className={styles.code}>404</p>
           <h1 className={styles.title}>ページが見つかりません</h1>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -28,7 +28,7 @@ const HomePage: FC = () => {
   return (
     <div className={styles.root}>
       <Header />
-      <main id="main-content" className={styles.main}>
+      <main className={styles.main}>
         <h1 className={styles.visuallyHidden}>鹿野壮のポートフォリオ - WORKS</h1>
         <Suspense fallback={null}>
           <ArticleGrid posts={publishedPosts} />

--- a/app/styles/globals.css
+++ b/app/styles/globals.css
@@ -322,24 +322,6 @@
     color: var(--text-inverse);
   }
 
-  /* Skip Navigation */
-  .skip-nav {
-    position: absolute;
-    top: -100%;
-    left: 50%;
-    z-index: 1000;
-    padding: var(--space-xs) var(--space-sm);
-    border-radius: var(--radius-sm);
-    background: var(--liquid-primary);
-    color: var(--text-inverse);
-    font-weight: 600;
-    text-decoration: none;
-    transform: translateX(-50%);
-  }
-
-  .skip-nav:focus {
-    top: var(--space-xs);
-  }
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## 概要

Tabキーで表示される「メインコンテンツへスキップ」ボタンが機能していなかったため、関連コードを削除。

## 変更点

- `layout.tsx` からスキップリンク (`<a href="#main-content">`) を削除
- `globals.css` から `.skip-nav` スタイルを削除
- 各ページの `<main>` から不要な `id="main-content"` を削除