### PR TITLE
feat: add gh skill Zenn article

### DIFF
--- a/content/posts/gh-skill-install-agent-skills.md
+++ b/content/posts/gh-skill-install-agent-skills.md
@@ -1,0 +1,14 @@
+---
+title: "gh skillが登場。GitHub公式のスキル管理ツールにnpx skillsから乗り換えた"
+slug: "gh-skill-install-agent-skills"
+date: "2026-04-19T00:00+09:00"
+published: true
+tags: []
+categories: []
+medium: "執筆記事"
+thumbnail: ""
+slides: ""
+linkUrl: "https://zenn.dev/ubie_dev/articles/gh-skill-install-agent-skills"
+targetUrl: "https://zenn.dev/ubie_dev/articles/gh-skill-install-agent-skills"
+hasDetail: false
+---

--- a/content/posts/gh-skill-install-agent-skills.md
+++ b/content/posts/gh-skill-install-agent-skills.md
@@ -1,7 +1,7 @@
 ---
 title: "gh skillが登場。GitHub公式のスキル管理ツールにnpx skillsから乗り換えた"
 slug: "gh-skill-install-agent-skills"
-date: "2026-04-19T00:00+09:00"
+date: "2026-04-17T00:00+09:00"
 published: true
 tags: []
 categories: []


### PR DESCRIPTION
## Summary
- Zenn記事「gh skillが登場。GitHub公式のスキル管理ツールにnpx skillsから乗り換えた」を `content/posts/` に追加
- 記事URL: https://zenn.dev/ubie_dev/articles/gh-skill-install-agent-skills
- `medium: "執筆記事"` / `targetUrl` を設定し、一覧から外部リンクとして遷移

## Test plan
- [x] `pnpm velite build` が通る
- [x] `pnpm test` が通る
- [ ] デプロイプレビューで記事カードが一覧に表示されることを確認
- [ ] カードクリックで Zenn 記事へ遷移することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)