### PR TITLE
chore: unify role title to "Staff Product Engineer"

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -14,7 +14,7 @@ import styles from "./page.module.css";
 
 import type { Metadata, NextPage } from "next";
 
-const aboutDescription = "鹿野壮（Takeshi Kano）のプロフィール。TypeScript・CSSを軸にプロダクト開発と執筆・登壇を行うフロントエンドエンジニア。著書・登壇・インタビュー情報を掲載。";
+const aboutDescription = "鹿野壮（Takeshi Kano）のプロフィール。TypeScript・CSSを軸にプロダクト開発と執筆・登壇を行うStaff Product Engineer。著書・登壇・インタビュー情報を掲載。";
 
 export const metadata: Metadata = {
   alternates: {
@@ -122,7 +122,7 @@ const AboutPage: NextPage = () => {
           {/* Profile Hero */}
           <div className={styles.profileHero}>
             <h1 className={styles.name}>鹿野 壮（たけし）</h1>
-            <p className={styles.role}>Staff Product Engineer @ Ubie</p>
+            <p className={styles.role}>Staff Product Engineer</p>
             <div className={styles.photoGrid}>
               <div className={styles.photoGridTop}>
                 <div className={styles.photoCell}>

--- a/app/constants/index.ts
+++ b/app/constants/index.ts
@@ -11,4 +11,4 @@ export const ogImageUrl = `${SiteUrl}/ogimage.png`;
 export const TwitterId = "tonkotsuboy_com";
 
 export const basicDescription =
-  "フロントエンドエンジニア鹿野壮のポートフォリオ。CSS・TypeScript・Claude Codeを活用したプロダクト開発、執筆、登壇情報を掲載。";
+  "Staff Product Engineer・鹿野壮のポートフォリオ。CSS・TypeScript・Claude Codeを活用したプロダクト開発、執筆、登壇情報を掲載。";


### PR DESCRIPTION
## Summary

About ページとサイト全体の meta description でブレていた肩書表記を "Staff Product Engineer" に統一。

- `app/about/page.tsx` のプロフィールヒーローから `@ Ubie` を削除し、ページ他所の表記と揃えた
- `app/about/page.tsx` の `aboutDescription` で「フロントエンドエンジニア」になっていた箇所を "Staff Product Engineer" に変更
- `app/constants/index.ts` の `basicDescription` も同様に "Staff Product Engineer" に統一

## Test plan

- [ ] `/about` のヒーローに "Staff Product Engineer" が表示されること
- [ ] `/about` 自己紹介本文の "Staff Product Engineer" が引き続き表示されること（変更なし）
- [ ] `/` と `/about` の `<meta name="description">` が統一された文言で出力されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)