### PR TITLE
feat(upcoming-talks): update section heading, remove eyebrow, add button hover

### DIFF
--- a/app/features/talks/UpcomingTalks/UpcomingTalks.module.css
+++ b/app/features/talks/UpcomingTalks/UpcomingTalks.module.css
@@ -18,35 +18,6 @@
   gap: 10px;
 }
 
-.eyebrowRow {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-
-.eyebrowDot {
-  display: block;
-  width: 8px;
-  height: 8px;
-  border-radius: var(--radius-full);
-  animation: pulse 2.4s var(--ease-liquid) infinite;
-  background: var(--liquid-primary);
-  box-shadow: 0 0 0 4px rgb(245 180 0 / 18%);
-}
-
-@keyframes pulse {
-  0%, 100% { box-shadow: 0 0 0 4px rgb(245 180 0 / 18%); }
-  50% { box-shadow: 0 0 0 8px rgb(245 180 0 / 5%); }
-}
-
-.eyebrow {
-  color: var(--liquid-primary-accessible);
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-}
-
 .sectionTitle {
   margin: 0;
   color: var(--text-primary);
@@ -156,7 +127,15 @@
   font-weight: 700;
   gap: 5px;
   letter-spacing: 0.02em;
+  transition:
+    background 0.2s var(--ease-liquid),
+    color 0.2s var(--ease-liquid);
   white-space: nowrap;
+}
+
+.card:hover .registerBtn {
+  background: var(--liquid-primary);
+  color: var(--text-on-yellow);
 }
 
 /* Responsive */
@@ -170,8 +149,3 @@
   }
 }
 
-@media (prefers-reduced-motion: reduce) {
-  .eyebrowDot {
-    animation: none;
-  }
-}

--- a/app/features/talks/UpcomingTalks/UpcomingTalks.module.css
+++ b/app/features/talks/UpcomingTalks/UpcomingTalks.module.css
@@ -138,6 +138,12 @@
   color: var(--text-on-yellow);
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .registerBtn {
+    transition: none;
+  }
+}
+
 /* Responsive */
 @media (width <= 768px) {
   .container {

--- a/app/features/talks/UpcomingTalks/UpcomingTalks.tsx
+++ b/app/features/talks/UpcomingTalks/UpcomingTalks.tsx
@@ -93,10 +93,10 @@ export const UpcomingTalks: FC<Props> = ({ talks }) => {
   }
 
   return (
-    <section className={styles.section} aria-label="だんだん登壇！どんどん登壇！">
+    <section className={styles.section} aria-labelledby="upcoming-talks-heading">
       <div className={styles.container}>
         <div className={styles.sectionHead}>
-          <h2 className={styles.sectionTitle}>だんだん登壇！どんどん登壇！</h2>
+          <h2 id="upcoming-talks-heading" className={styles.sectionTitle}>だんだん登壇！どんどん登壇！</h2>
         </div>
 
         <div className={styles.grid}>

--- a/app/features/talks/UpcomingTalks/UpcomingTalks.tsx
+++ b/app/features/talks/UpcomingTalks/UpcomingTalks.tsx
@@ -93,14 +93,10 @@ export const UpcomingTalks: FC<Props> = ({ talks }) => {
   }
 
   return (
-    <section className={styles.section} aria-label="直近の登壇予定">
+    <section className={styles.section} aria-label="だんだん登壇！どんどん登壇！">
       <div className={styles.container}>
         <div className={styles.sectionHead}>
-          <div className={styles.eyebrowRow}>
-            <span className={styles.eyebrowDot} aria-hidden="true" />
-            <span className={styles.eyebrow}>Upcoming</span>
-          </div>
-          <h2 className={styles.sectionTitle}>直近の登壇予定</h2>
+          <h2 className={styles.sectionTitle}>だんだん登壇！どんどん登壇！</h2>
         </div>
 
         <div className={styles.grid}>


### PR DESCRIPTION
## 変更概要

UpcomingTalks セクションの UI を3点更新。

## 変更点

- **「UPCOMING」eyebrow を削除**: 黄色い点滅ドットと "UPCOMING" テキストの行を除去
- **セクション見出しを変更**: 「直近の登壇予定」→「だんだん登壇！どんどん登壇！」
- **参加申し込みボタンにホバー効果を追加**: カードホバー時にボタン背景が黄色（`--liquid-primary`）・テキストが `--text-on-yellow` に遷移

## テスト方法

- TOPページの登壇予定セクションを確認
- eyebrow 行（黄色ドット + "UPCOMING"）が非表示になっていること
- 見出しが「だんだん登壇！どんどん登壇！」になっていること
- カードにホバーしたとき「参加申し込み」ボタンが黄色に変わること

🤖 Generated with [Claude Code](https://claude.com/claude-code)