### PR TITLE
feat(posts): CSSNite「Claude Codeとフロントエンド開発」登壇実績を追加

### DIFF
--- a/content/posts/cssnite_claude_code_2026.md
+++ b/content/posts/cssnite_claude_code_2026.md
@@ -1,0 +1,14 @@
+---
+title: "CSSNite「Claude Codeとフロントエンド開発──全社員がAIエージェントを活用するUbieの実践事例」に登壇"
+slug: "cssnite_claude_code_2026"
+date: "2026-04-24T21:00+09:00"
+published: true
+tags: []
+categories: []
+medium: "登壇"
+thumbnail: "/images/og/cssnite-20260424.png"
+slides: ""
+linkUrl: "https://cssnite.doorkeeper.jp/events/195497"
+targetUrl: "https://cssnite.doorkeeper.jp/events/195497"
+hasDetail: false
+---


### PR DESCRIPTION
## Summary

- 2026-04-24 開催の CSSNite「Claude Codeとフロントエンド開発──全社員がAIエージェントを活用するUbieの実践事例」への登壇を実績として `content/posts/` に追加
- イベント URL: https://cssnite.doorkeeper.jp/events/195497
- サムネイルは既存の `/images/og/cssnite-20260424.png` を再利用
- `medium: "登壇"` として他の CSSNite 実績（例: `cssnite_asamade3_js_2025.md`）と同じスキーマで登録

## Test plan

- [x] `pnpm exec velite build` が成功し、新規エントリが `.velite/posts.json` に含まれることを確認
- [x] `pnpm exec tcm app` が成功
- [x] `pnpm exec vitest run`（6 files / 29 tests）すべてパス
- [ ] プレビュー環境で WORKS セクションにカードが表示されることを目視確認

https://claude.ai/code/session_01CJDga3QmcxNaFQ5aTuPCtL

---
_Generated by [Claude Code](https://claude.ai/code/session_01CJDga3QmcxNaFQ5aTuPCtL)_