### PR TITLE
feat(about): add PersonCard component with three layout variants

### DIFF
--- a/app/about/page.module.css
+++ b/app/about/page.module.css
@@ -113,6 +113,10 @@
   height: 16px;
 }
 
+.personCardWrapper {
+  margin-bottom: var(--space-xl);
+}
+
 /* Bio Card */
 .bioCard {
   padding: var(--space-md);

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -214,7 +214,7 @@ const AboutPage: NextPage = () => {
             <PersonCard
               buttonHref="#bio"
               imageSrc="/images/about/speaking.jpg"
-              imageAlt="ギャグが楽しいエンジニア"
+              imageAlt="登壇中の鹿野 壮"
               tagline="TypeScript・CSS を軸にプロダクト開発と発信を行うエンジニア"
               variant="horizontal"
             />

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -6,6 +6,7 @@ import { siGithub, siQiita, siX, siZenn } from "simple-icons";
 
 import { SimpleIcon } from "../components/ui/icons/SimpleIcon";
 import { ogImageUrl, WithSiteTitle } from "../constants";
+import { PersonCard } from "../features/about/PersonCard/PersonCard";
 import { Footer } from "../features/layout/Footer";
 import { Header } from "../features/layout/Header";
 import hoverStyles from "../styles/card-hover.module.css";
@@ -208,8 +209,19 @@ const AboutPage: NextPage = () => {
             </div>
           </div>
 
+          {/* Person Card */}
+          <div className={styles.personCardWrapper}>
+            <PersonCard
+              buttonHref="#bio"
+              imageSrc="/images/about/speaking.jpg"
+              imageAlt="ギャグが楽しいエンジニア"
+              tagline="TypeScript・CSS を軸にプロダクト開発と発信を行うエンジニア"
+              variant="horizontal"
+            />
+          </div>
+
           {/* Bio */}
-          <section className={styles.section}>
+          <section id="bio" className={styles.section}>
             <h2 className={styles.sectionLabel}>自己紹介</h2>
             <div className={styles.bioCard}>
               <p className={styles.bioText}>

--- a/app/features/about/PersonCard/PersonCard.module.css
+++ b/app/features/about/PersonCard/PersonCard.module.css
@@ -189,8 +189,12 @@
 
 .overlapRoot {
   --overlap-img-size: 170px;
-  --overlap-img-offset: 90px;
-  --overlap-panel-inset: 110px;
+
+  /* img は左端より内側に 5px ずらして配置: offset = size / 2 + 5px */
+  --overlap-img-offset: calc(var(--overlap-img-size) / 2 + 5px);
+
+  /* panel のテキスト開始位置 = img offset + 内側の余白 20px */
+  --overlap-panel-inset: calc(var(--overlap-img-offset) + 20px);
 
   position: relative;
   display: flex;

--- a/app/features/about/PersonCard/PersonCard.module.css
+++ b/app/features/about/PersonCard/PersonCard.module.css
@@ -1,0 +1,258 @@
+/* === Shared Primitives === */
+
+.eyebrow {
+  margin: 0 0 var(--space-xs);
+  color: var(--text-tertiary);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.headline {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 1.375rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  line-height: 1.55;
+  overflow-wrap: break-word;
+  text-wrap: pretty;
+  word-break: keep-all;
+}
+
+.headlineCenter {
+  text-align: center;
+}
+
+/* === Avatar Portrait === */
+
+.portrait {
+  position: relative;
+  overflow: hidden;
+  width: 100%;
+  height: 100%;
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 70%),
+    inset 0 -1px 0 rgb(0 0 0 / 6%),
+    0 6px 18px rgb(0 0 0 / 6%);
+}
+
+.portraitImg {
+  object-fit: cover;
+  object-position: center top;
+}
+
+.portraitPortrait {
+  border-radius: var(--radius-md);
+  aspect-ratio: 3 / 4;
+}
+
+.portraitCircle {
+  border-radius: var(--radius-full);
+}
+
+.portraitRounded {
+  border: 4px solid rgb(255 255 255 / 85%);
+  border-radius: 24px;
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 70%),
+    0 6px 18px rgb(0 0 0 / 8%);
+}
+
+.placeholderSvg {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+/* === Primary Button === */
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  padding: 10px 20px;
+  border: 1px solid rgb(255 255 255 / 45%);
+  border-radius: var(--radius-full);
+  background: linear-gradient(180deg, #fd6, #f5b400);
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 60%),
+    0 6px 16px rgb(245 180 0 / 30%),
+    0 1px 3px rgb(0 0 0 / 6%);
+  color: var(--text-on-yellow);
+  cursor: pointer;
+  font-size: 0.9375rem;
+  font-weight: 700;
+  gap: 8px;
+  letter-spacing: 0.01em;
+  text-decoration: none;
+  transition:
+    transform var(--dur-fast) var(--ease-liquid),
+    box-shadow var(--dur-base) var(--ease-liquid);
+  white-space: nowrap;
+}
+
+.btn svg {
+  transition: transform var(--dur-base) var(--ease-liquid);
+}
+
+.btn:hover {
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 70%),
+    0 10px 22px rgb(245 180 0 / 42%),
+    0 1px 3px rgb(0 0 0 / 6%);
+  transform: translateY(-1px);
+}
+
+.btn:hover svg {
+  transform: translateX(2px);
+}
+
+.btn:active {
+  transform: translateY(0) scale(0.98);
+}
+
+/* === Glass Card Base (Variant A + B) === */
+
+.card {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid var(--glass-card-border);
+  border-radius: var(--radius-lg);
+  backdrop-filter: blur(12px);
+  background: var(--glass-card-bg);
+  box-shadow:
+    0 8px 32px rgb(0 0 0 / 6%),
+    inset 0 1px 0 var(--highlight-top),
+    inset 0 -1px 0 rgb(0 0 0 / 5%);
+  transition:
+    background var(--dur-base) var(--ease-liquid),
+    border-color var(--dur-base) var(--ease-liquid),
+    box-shadow var(--dur-base) var(--ease-liquid);
+}
+
+.card:hover {
+  border-color: var(--glass-card-hover-border);
+  background: var(--glass-card-hover-bg);
+  box-shadow: var(--shadow-elevated);
+}
+
+/* === Variant A: Horizontal === */
+
+.horizontal {
+  display: grid;
+  align-items: stretch;
+  padding: var(--space-md);
+  gap: var(--space-lg);
+  grid-template-columns: 160px 1fr;
+}
+
+.horizontalMedia {
+  display: flex;
+  width: 160px;
+}
+
+.horizontalBody {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  justify-content: center;
+  padding: var(--space-xs) 0;
+}
+
+.actions {
+  margin-top: var(--space-md);
+}
+
+/* === Variant B: Stacked === */
+
+.stacked {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: var(--space-xl) var(--space-lg) var(--space-lg);
+  gap: var(--space-sm);
+  text-align: center;
+}
+
+.stackedMedia {
+  width: 128px;
+  height: 128px;
+  margin-bottom: var(--space-xs);
+}
+
+/* === Variant C: Overlap === */
+
+.overlapRoot {
+  position: relative;
+  display: flex;
+  min-height: 200px;
+  align-items: stretch;
+  padding: var(--space-lg) var(--space-lg) var(--space-lg) 90px;
+}
+
+.overlapMedia {
+  position: absolute;
+  z-index: 2;
+  top: 50%;
+  left: 0;
+  width: 170px;
+  height: 170px;
+  filter: drop-shadow(0 10px 24px rgb(0 0 0 / 10%));
+  transform: translateY(-50%);
+  transition: transform var(--dur-base) var(--ease-liquid);
+}
+
+.overlapRoot:hover .overlapMedia {
+  transform: translateY(calc(-50% - 2px));
+}
+
+.overlapPanel {
+  display: flex;
+  min-height: 160px;
+  flex: 1;
+  flex-direction: column;
+  justify-content: center;
+  padding: var(--space-md) var(--space-lg) var(--space-md) 110px;
+  border: 1px solid var(--glass-card-border);
+  border-radius: var(--radius-lg);
+  backdrop-filter: blur(12px);
+  background: var(--glass-card-bg);
+  box-shadow:
+    0 8px 32px rgb(0 0 0 / 6%),
+    inset 0 1px 0 var(--highlight-top),
+    inset 0 -1px 0 rgb(0 0 0 / 5%);
+  transition:
+    background var(--dur-base) var(--ease-liquid),
+    border-color var(--dur-base) var(--ease-liquid),
+    box-shadow var(--dur-base) var(--ease-liquid);
+}
+
+.overlapRoot:hover .overlapPanel {
+  border-color: var(--glass-card-hover-border);
+  background: var(--glass-card-hover-bg);
+  box-shadow: var(--shadow-elevated);
+}
+
+.overlapActions {
+  margin-top: var(--space-md);
+}
+
+/* === Responsive === */
+
+@media (width <= 600px) {
+  .horizontal {
+    grid-template-columns: 1fr;
+    justify-items: center;
+  }
+
+  .horizontalMedia {
+    width: 120px;
+  }
+
+  .horizontalBody {
+    align-items: center;
+    padding: 0;
+    text-align: center;
+  }
+}

--- a/app/features/about/PersonCard/PersonCard.module.css
+++ b/app/features/about/PersonCard/PersonCard.module.css
@@ -112,6 +112,11 @@
   transform: translateY(0) scale(0.98);
 }
 
+.btn:focus-visible {
+  outline: 2px solid var(--liquid-primary);
+  outline-offset: 3px;
+}
+
 /* === Glass Card Base (Variant A + B) === */
 
 .card {
@@ -149,7 +154,6 @@
 
 .horizontalMedia {
   display: flex;
-  width: 160px;
 }
 
 .horizontalBody {
@@ -184,11 +188,15 @@
 /* === Variant C: Overlap === */
 
 .overlapRoot {
+  --overlap-img-size: 170px;
+  --overlap-img-offset: 90px;
+  --overlap-panel-inset: 110px;
+
   position: relative;
   display: flex;
   min-height: 200px;
   align-items: stretch;
-  padding: var(--space-lg) var(--space-lg) var(--space-lg) 90px;
+  padding: var(--space-lg) var(--space-lg) var(--space-lg) var(--overlap-img-offset);
 }
 
 .overlapMedia {
@@ -196,8 +204,8 @@
   z-index: 2;
   top: 50%;
   left: 0;
-  width: 170px;
-  height: 170px;
+  width: var(--overlap-img-size);
+  height: var(--overlap-img-size);
   filter: drop-shadow(0 10px 24px rgb(0 0 0 / 10%));
   transform: translateY(-50%);
   transition: transform var(--dur-base) var(--ease-liquid);
@@ -213,7 +221,7 @@
   flex: 1;
   flex-direction: column;
   justify-content: center;
-  padding: var(--space-md) var(--space-lg) var(--space-md) 110px;
+  padding: var(--space-md) var(--space-lg) var(--space-md) var(--overlap-panel-inset);
   border: 1px solid var(--glass-card-border);
   border-radius: var(--radius-lg);
   backdrop-filter: blur(12px);
@@ -253,6 +261,31 @@
   .horizontalBody {
     align-items: center;
     padding: 0;
+    text-align: center;
+  }
+
+  .overlapRoot {
+    --overlap-img-size: 128px;
+
+    flex-direction: column;
+    align-items: center;
+    padding: var(--space-lg);
+    gap: var(--space-md);
+  }
+
+  .overlapMedia {
+    position: static;
+    transform: none;
+  }
+
+  .overlapRoot:hover .overlapMedia {
+    transform: none;
+  }
+
+  .overlapPanel {
+    width: 100%;
+    min-height: 0;
+    padding: var(--space-md) var(--space-lg);
     text-align: center;
   }
 }

--- a/app/features/about/PersonCard/PersonCard.tsx
+++ b/app/features/about/PersonCard/PersonCard.tsx
@@ -1,0 +1,139 @@
+import clsx from "clsx";
+import Image from "next/image";
+import Link from "next/link";
+
+import styles from "./PersonCard.module.css";
+
+import type { FC } from "react";
+
+type Variant = "horizontal" | "overlap" | "stacked";
+
+type Props = {
+  buttonHref?: string;
+  buttonLabel?: string;
+  imageAlt?: string;
+  imageSrc?: string;
+  tagline: string;
+  variant?: Variant;
+};
+
+const AvatarPlaceholder: FC = () => (
+  <svg
+    aria-hidden="true"
+    className={styles.placeholderSvg}
+    preserveAspectRatio="xMidYMax meet"
+    viewBox="0 0 100 100"
+  >
+    <defs>
+      <linearGradient id="pcGrad" x1="0" x2="0" y1="0" y2="1">
+        <stop offset="0" stopColor="#FFE066" />
+        <stop offset="1" stopColor="#F5B400" />
+      </linearGradient>
+    </defs>
+    <rect fill="url(#pcGrad)" height="100" width="100" />
+    <circle cx="50" cy="40" fill="rgba(255,255,255,0.55)" r="16" />
+    <path d="M18 100 C 22 74, 38 62, 50 62 C 62 62, 78 74, 82 100 Z" fill="rgba(255,255,255,0.55)" />
+  </svg>
+);
+
+const CardButton: FC<{ href: string; label: string }> = ({ href, label }) => (
+  <Link className={styles.btn} href={href}>
+    <span>{label}</span>
+    <svg
+      aria-hidden="true"
+      fill="none"
+      height="14"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2.5"
+      viewBox="0 0 24 24"
+      width="14"
+    >
+      <path d="M5 12h14" />
+      <path d="m13 6 6 6-6 6" />
+    </svg>
+  </Link>
+);
+
+type AvatarProps = {
+  alt: string;
+  shape: "circle" | "portrait" | "rounded";
+  src?: string | undefined;
+};
+
+const Avatar: FC<AvatarProps> = ({ alt, shape, src }) => (
+  <div
+    className={clsx(styles.portrait, {
+      [styles.portraitCircle]: shape === "circle",
+      [styles.portraitPortrait]: shape === "portrait",
+      [styles.portraitRounded]: shape === "rounded",
+    })}
+  >
+    {src ? (
+      <Image
+        alt={alt}
+        className={styles.portraitImg}
+        fill
+        sizes="(max-width: 768px) 128px, 170px"
+        src={src}
+      />
+    ) : (
+      <AvatarPlaceholder />
+    )}
+  </div>
+);
+
+export const PersonCard: FC<Props> = ({
+  buttonHref = "#",
+  buttonLabel = "詳しく見る",
+  imageAlt = "",
+  imageSrc,
+  tagline,
+  variant = "horizontal",
+}) => {
+  if (variant === "stacked") {
+    return (
+      <article className={clsx(styles.card, styles.stacked)}>
+        <div className={styles.stackedMedia}>
+          <Avatar alt={imageAlt} shape="circle" src={imageSrc} />
+        </div>
+        <p className={styles.eyebrow}>PROFILE</p>
+        <h3 className={clsx(styles.headline, styles.headlineCenter)}>{tagline}</h3>
+        <CardButton href={buttonHref} label={buttonLabel} />
+      </article>
+    );
+  }
+
+  if (variant === "overlap") {
+    return (
+      <article className={styles.overlapRoot}>
+        <div className={styles.overlapMedia}>
+          <Avatar alt={imageAlt} shape="rounded" src={imageSrc} />
+        </div>
+        <div className={styles.overlapPanel}>
+          <p className={styles.eyebrow}>PROFILE</p>
+          <h3 className={styles.headline}>{tagline}</h3>
+          <div className={styles.overlapActions}>
+            <CardButton href={buttonHref} label={buttonLabel} />
+          </div>
+        </div>
+      </article>
+    );
+  }
+
+  return (
+    <article className={clsx(styles.card, styles.horizontal)}>
+      <div className={styles.horizontalMedia}>
+        <Avatar alt={imageAlt} shape="portrait" src={imageSrc} />
+      </div>
+      <div className={styles.horizontalBody}>
+        <p className={styles.eyebrow}>PROFILE</p>
+        <h3 className={styles.headline}>{tagline}</h3>
+        <div className={styles.actions}>
+          <CardButton href={buttonHref} label={buttonLabel} />
+        </div>
+      </div>
+    </article>
+  );
+};

--- a/app/features/about/PersonCard/PersonCard.tsx
+++ b/app/features/about/PersonCard/PersonCard.tsx
@@ -85,7 +85,7 @@ const Avatar: FC<AvatarProps> = ({ alt, shape, src }) => (
 );
 
 export const PersonCard: FC<Props> = ({
-  buttonHref = "#",
+  buttonHref,
   buttonLabel = "詳しく見る",
   imageAlt = "",
   imageSrc,
@@ -100,7 +100,7 @@ export const PersonCard: FC<Props> = ({
         </div>
         <p className={styles.eyebrow}>PROFILE</p>
         <h3 className={clsx(styles.headline, styles.headlineCenter)}>{tagline}</h3>
-        <CardButton href={buttonHref} label={buttonLabel} />
+        {buttonHref && <CardButton href={buttonHref} label={buttonLabel} />}
       </article>
     );
   }
@@ -114,9 +114,11 @@ export const PersonCard: FC<Props> = ({
         <div className={styles.overlapPanel}>
           <p className={styles.eyebrow}>PROFILE</p>
           <h3 className={styles.headline}>{tagline}</h3>
-          <div className={styles.overlapActions}>
-            <CardButton href={buttonHref} label={buttonLabel} />
-          </div>
+          {buttonHref && (
+            <div className={styles.overlapActions}>
+              <CardButton href={buttonHref} label={buttonLabel} />
+            </div>
+          )}
         </div>
       </article>
     );
@@ -130,9 +132,11 @@ export const PersonCard: FC<Props> = ({
       <div className={styles.horizontalBody}>
         <p className={styles.eyebrow}>PROFILE</p>
         <h3 className={styles.headline}>{tagline}</h3>
-        <div className={styles.actions}>
-          <CardButton href={buttonHref} label={buttonLabel} />
-        </div>
+        {buttonHref && (
+          <div className={styles.actions}>
+            <CardButton href={buttonHref} label={buttonLabel} />
+          </div>
+        )}
       </div>
     </article>
   );

--- a/app/features/about/PersonCard/PersonCard.tsx
+++ b/app/features/about/PersonCard/PersonCard.tsx
@@ -25,12 +25,12 @@ const AvatarPlaceholder: FC = () => (
     viewBox="0 0 100 100"
   >
     <defs>
-      <linearGradient id="pcGrad" x1="0" x2="0" y1="0" y2="1">
+      <linearGradient id="avatarPlaceholderGrad" x1="0" x2="0" y1="0" y2="1">
         <stop offset="0" stopColor="#FFE066" />
         <stop offset="1" stopColor="#F5B400" />
       </linearGradient>
     </defs>
-    <rect fill="url(#pcGrad)" height="100" width="100" />
+    <rect fill="url(#avatarPlaceholderGrad)" height="100" width="100" />
     <circle cx="50" cy="40" fill="rgba(255,255,255,0.55)" r="16" />
     <path d="M18 100 C 22 74, 38 62, 50 62 C 62 62, 78 74, 82 100 Z" fill="rgba(255,255,255,0.55)" />
   </svg>

--- a/app/features/talks/UpcomingTalks/UpcomingTalks.module.css
+++ b/app/features/talks/UpcomingTalks/UpcomingTalks.module.css
@@ -10,12 +10,8 @@
   margin: 0 auto;
 }
 
-/* Section header */
 .sectionHead {
-  display: flex;
-  flex-direction: column;
-  margin-bottom: var(--space-md);
-  gap: 10px;
+  margin: 0 0 var(--space-lg);
 }
 
 .sectionTitle {
@@ -128,8 +124,8 @@
   gap: 5px;
   letter-spacing: 0.02em;
   transition:
-    background 0.2s var(--ease-liquid),
-    color 0.2s var(--ease-liquid);
+    background var(--dur-base) var(--ease-liquid),
+    color var(--dur-base) var(--ease-liquid);
   white-space: nowrap;
 }
 

--- a/app/features/talks/UpcomingTalks/UpcomingTalks.module.css
+++ b/app/features/talks/UpcomingTalks/UpcomingTalks.module.css
@@ -18,35 +18,6 @@
   gap: 10px;
 }
 
-.eyebrowRow {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-
-.eyebrowDot {
-  display: block;
-  width: 8px;
-  height: 8px;
-  border-radius: var(--radius-full);
-  animation: pulse 2.4s var(--ease-liquid) infinite;
-  background: var(--liquid-primary);
-  box-shadow: 0 0 0 4px rgb(245 180 0 / 18%);
-}
-
-@keyframes pulse {
-  0%, 100% { box-shadow: 0 0 0 4px rgb(245 180 0 / 18%); }
-  50% { box-shadow: 0 0 0 8px rgb(245 180 0 / 5%); }
-}
-
-.eyebrow {
-  color: var(--liquid-primary-accessible);
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-}
-
 .sectionTitle {
   margin: 0;
   color: var(--text-primary);
@@ -156,7 +127,15 @@
   font-weight: 700;
   gap: 5px;
   letter-spacing: 0.02em;
+  transition:
+    background 0.2s var(--ease-liquid),
+    color 0.2s var(--ease-liquid);
   white-space: nowrap;
+}
+
+.card:hover .registerBtn {
+  background: var(--liquid-primary);
+  color: var(--text-on-yellow);
 }
 
 /* Responsive */
@@ -170,8 +149,3 @@
   }
 }
 
-@media (prefers-reduced-motion: reduce) {
-  .eyebrowDot {
-    animation: none;
-  }
-}

--- a/app/features/talks/UpcomingTalks/UpcomingTalks.module.css
+++ b/app/features/talks/UpcomingTalks/UpcomingTalks.module.css
@@ -138,6 +138,12 @@
   color: var(--text-on-yellow);
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .registerBtn {
+    transition: none;
+  }
+}
+
 /* Responsive */
 @media (width <= 768px) {
   .container {

--- a/app/features/talks/UpcomingTalks/UpcomingTalks.tsx
+++ b/app/features/talks/UpcomingTalks/UpcomingTalks.tsx
@@ -93,10 +93,10 @@ export const UpcomingTalks: FC<Props> = ({ talks }) => {
   }
 
   return (
-    <section className={styles.section} aria-label="だんだん登壇！どんどん登壇！">
+    <section className={styles.section} aria-labelledby="upcoming-talks-heading">
       <div className={styles.container}>
         <div className={styles.sectionHead}>
-          <h2 className={styles.sectionTitle}>だんだん登壇！どんどん登壇！</h2>
+          <h2 id="upcoming-talks-heading" className={styles.sectionTitle}>だんだん登壇！どんどん登壇！</h2>
         </div>
 
         <div className={styles.grid}>

--- a/app/features/talks/UpcomingTalks/UpcomingTalks.tsx
+++ b/app/features/talks/UpcomingTalks/UpcomingTalks.tsx
@@ -93,14 +93,10 @@ export const UpcomingTalks: FC<Props> = ({ talks }) => {
   }
 
   return (
-    <section className={styles.section} aria-label="直近の登壇予定">
+    <section className={styles.section} aria-label="だんだん登壇！どんどん登壇！">
       <div className={styles.container}>
         <div className={styles.sectionHead}>
-          <div className={styles.eyebrowRow}>
-            <span className={styles.eyebrowDot} aria-hidden="true" />
-            <span className={styles.eyebrow}>Upcoming</span>
-          </div>
-          <h2 className={styles.sectionTitle}>直近の登壇予定</h2>
+          <h2 className={styles.sectionTitle}>だんだん登壇！どんどん登壇！</h2>
         </div>
 
         <div className={styles.grid}>


### PR DESCRIPTION
## Summary

- `app/features/about/PersonCard/` に PersonCard コンポーネントを新規追加
- `horizontal` / `stacked` / `overlap` の 3 バリアントを variant prop で切り替え可能
- Liquid Glass デザインシステム（glass card + yellow pill button）準拠
- About ページのメインプロフィール位置（social pills → PersonCard → 自己紹介）に統合
- UpcomingTalks の `.sectionHead` クラス未定義バグを修正し、タイトル下の gap を拡大

## Test plan

- [ ] `/about` ページで PersonCard（横並び）が social pills 直下に表示される
- [ ] 「詳しく見る」ボタンで `#bio` セクションへスクロールする
- [ ] ボタンホバー時に黄色 glow + arrow が右へ移動する
- [ ] モバイル（600px 以下）で縦積みレイアウトに切り替わる
- [ ] UpcomingTalks セクションのタイトル下の gap が広がっている

🤖 Generated with [Claude Code](https://claude.com/claude-code)