### PR TITLE
content: Findyインタビューを外部リンク直接遷移に変更

### DIFF
--- a/content/posts/findy_interview.md
+++ b/content/posts/findy_interview.md
@@ -10,7 +10,7 @@ thumbnail: "/images/og/findy_interview.png"
 slides: ""
 linkUrl: "https://findy-code.io/engineer-lab/tonkotsuboy-output"
 targetUrl: "https://findy-code.io/engineer-lab/tonkotsuboy-output"
-hasDetail: true
+hasDetail: false
 ---
 
 Findyさんからインタビューを受けました。


### PR DESCRIPTION
## Summary
- 「Findyさんから、登壇中毒についてのインタビューを受けました」エントリーの `hasDetail` を `false` に変更
- 詳細ページを経由せず、Findyのインタビュー記事へ直接遷移するように

## Test plan
- [ ] 記事一覧で該当エントリーをクリックすると、`https://findy-code.io/engineer-lab/tonkotsuboy-output` に直接遷移すること
- [ ] 詳細ページ `/entry/findy_interview` が生成されないこと（sitemap・feed からも除外される）

https://claude.ai/code/session_01KXDFq7uFtNAhDbNExpqbD6

---
_Generated by [Claude Code](https://claude.ai/code/session_01KXDFq7uFtNAhDbNExpqbD6)_