### PR TITLE
fix: prevent fixed header from overlapping the entry page hero

### DIFF
--- a/app/entry/[slug]/page.module.css
+++ b/app/entry/[slug]/page.module.css
@@ -1,10 +1,17 @@
 .surface {
   min-height: 100vh;
   padding: clamp(var(--space-md), 4vw, var(--space-2xl));
+  padding-top: calc(64px + var(--space-lg));
   background:
     radial-gradient(circle at 20% 20%, rgb(77 96 255 / 8%), transparent 30%),
     radial-gradient(circle at 80% 10%, rgb(255 179 71 / 8%), transparent 30%),
     color-mix(in srgb, var(--bg-primary) 92%, transparent);
+}
+
+@media (width <= 768px) {
+  .surface {
+    padding-top: calc(56px + var(--space-lg));
+  }
 }
 
 .hero {

--- a/app/styles/globals.css
+++ b/app/styles/globals.css
@@ -158,6 +158,13 @@
     -moz-osx-font-smoothing: grayscale;
     text-rendering: optimizeLegibility;
     overflow-y: scroll;
+    scroll-padding-top: calc(64px + var(--space-lg));
+  }
+
+  @media (width <= 768px) {
+    html {
+      scroll-padding-top: calc(56px + var(--space-lg));
+    }
   }
 
   body {


### PR DESCRIPTION
## Problem

On `/entry/[slug]` detail pages, the article's category chip and title sat directly under the fixed header on initial render — the header visually clipped the top of the hero block.

The root cause: nothing in `.surface` (entry page) or in `html` (global) accounted for the 64px fixed header height. The home (`app/page.module.css:13`) and about layouts already use `padding-top: calc(64px + var(--space-lg))`, but the entry surface relied on a generic `padding: clamp(...)` whose top maxed out at `--space-2xl` (4rem).

## Fix

Two narrowly-scoped CSS changes:

- **`app/entry/[slug]/page.module.css`** — add an explicit `padding-top: calc(64px + var(--space-lg))` to `.surface` (mobile: 56px), matching the existing home / about pattern.
- **`app/styles/globals.css`** — add `scroll-padding-top: calc(64px + var(--space-lg))` on `html`. This handles the related-but-separate case of in-page anchor jumps generated by `rehypeAutolinkHeadings`: clicking a heading anchor used to land underneath the header.

Both values live alongside the existing `--space-lg` token; mobile uses 56px to match the responsive header height already coded in `app/page.module.css`.

## Test plan
- [ ] Open any `/entry/<slug>` page (e.g. `/entry/findy_20240619`) on desktop and confirm the eyebrow chip / title sit fully below the header on initial load.
- [ ] Click any heading anchor on a long entry and confirm the heading lands below the header, not underneath it.
- [ ] Verify the same on mobile width (≤ 768px).

🤖 Generated with [Claude Code](https://claude.com/claude-code)