### PR TITLE
feat: link TechFeed Advance ":is() and :not()" CSS tips article

### DIFF
--- a/content/posts/techfeed-advance-css-is-not.md
+++ b/content/posts/techfeed-advance-css-is-not.md
@@ -1,0 +1,14 @@
+---
+title: "使ってますか? CSSの:is()と:not()で複数セレクタ管理をラクにしよう"
+slug: "techfeed-advance-css-is-not"
+date: "2023-02-06T16:00+09:00"
+published: true
+tags: []
+categories: []
+medium: "執筆記事"
+thumbnail: ""
+slides: ""
+linkUrl: "https://techfeed.io/entries/63db5a9aaf090a2b746321a4"
+targetUrl: "https://techfeed.io/entries/63db5a9aaf090a2b746321a4"
+hasDetail: false
+---


### PR DESCRIPTION
## Summary
- Register the TechFeed Advance article *使ってますか? CSSの:is()と:not()で複数セレクタ管理をラクにしよう* (published 2023-02-06) as a portfolio entry under `medium: "執筆記事"`.
- The entry is the 3rd in the *鹿野壮 presents - 覚えておきたい今月の最新CSSテクニック* series and was not yet on kano.codes.
- External link: <https://techfeed.io/entries/63db5a9aaf090a2b746321a4>

## Test plan
- [x] `pnpm exec velite build` succeeds and the entry appears in `.velite/posts.json` with the correct `permalink`
- [x] `pnpm test` passes locally
- [x] `pnpm lint:next:fix` reports no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)