### PR TITLE
refactor(styles): カラートークンをOkLCH化＋アンビエントメッシュ整理

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -3,6 +3,18 @@
 > AI コーディングエージェント向けのデザインシステム仕様書。
 > kano.codes（鹿野 壮 / Takeshi Kano）のポートフォリオサイトに合わせた UI を生成する際、本ファイルを読み込んで使用すること。
 
+## 0. Color Notation Policy（最重要）
+
+**色相を持つ値はすべて `oklch()` で記述する。** `rgb()` / `#RRGGBB` を新規に持ち込まない。
+
+- 例: `oklch(0.787 0.158 79)` = `L`（明度 0–1）/ `C`（彩度 0–約 0.4）/ `H`（色相 0–360）
+- 透過は `oklch(L C H / a)` の形（`a` は 0–1 または `%`）
+- グラデーションは必ず補間色空間を明示: `linear-gradient(in oklch 90deg, ..., ...)`
+- 例外: **白／黒のみの透過オーバーレイ**（影・ガラス面の鏡面ハイライト）は `rgba(255, 255, 255, a)` / `rgba(0, 0, 0, a)` を許容（色相情報を持たないため OkLCH 化のメリットがない）
+- どうしても 16 進が必要な場合（外部ブランドカラーの再現など）も、最初に `oklch()` で書き直してから使うこと
+
+**理由**: OkLCH は知覚的に均等な色空間。明度・彩度を独立に操作でき、`oklch(from var(--base) calc(l + 0.1) c h)` で派生色を CSS だけで生成できる。グラデの中央色もくすまない。
+
 ## 1. Visual Theme & Atmosphere
 
 **"透明なガラスの板が、やわらかい光の上に浮いている"** — Apple の Liquid Glass 表現にインスパイアされた、技術者の私的ポートフォリオ。
@@ -16,37 +28,40 @@
 
 ### Key Color (Yellow)
 
-| Token | Hex | Role |
+| Token | Value | Role |
 |---|---|---|
-| `--liquid-primary` | `#F5B400` | キーカラー・フォーカスリング・アクティブ状態（背景色として使用） |
-| `--liquid-primary-vibrant` | `#FFBE0A` | リンクホバー・アクセント強調（背景色として使用） |
-| `--liquid-primary-dark` | `#C98A00` | 装飾・ボーダー用（前景テキストには使わない） |
-| `--liquid-primary-accessible` | Light: `#7A5200` / Dark: `#C98A00` | **前景テキスト専用**（WCAG AA 準拠: ライト 6.06:1 ✅） |
-| `--text-on-yellow` | `#1A1400` | 黄色背景上のテキスト（ボタン・アクティブタグ等。10.75:1 ✅） |
+| `--liquid-primary` | `oklch(0.787 0.158 79)` | キーカラー・フォーカスリング・アクティブ状態（背景色として使用） |
+| `--liquid-primary-vibrant` | `oklch(0.815 0.173 84)` | リンクホバー・アクセント強調（背景色として使用） |
+| `--liquid-primary-dark` | `oklch(0.645 0.139 71)` | 装飾・ボーダー用（前景テキストには使わない） |
+| `--liquid-primary-accessible` | Light: `oklch(0.407 0.087 64)` / Dark: `oklch(0.645 0.139 71)` | **前景テキスト専用**（WCAG AA 準拠: ライト 6.06:1 ✅） |
+| `--text-on-yellow` | `oklch(0.152 0.018 79)` | 黄色背景上のテキスト（ボタン・アクティブタグ等。10.75:1 ✅） |
+| `--liquid-accent` | `oklch(0.65 0.227 17)` | エラー画面等のアクセント赤（`app/error.module.css` で使用中） |
 
 ### Neutrals
 
 | Token | Light | Dark | Role |
 |---|---|---|---|
-| `--text-primary` | `#1F2937` | `#F5F5F7` | 本文・見出し |
-| `--text-secondary` | `#545B64` ✅ | `#A1A1A6` | メタ情報・ラベル（Light 5.94:1） |
-| `--text-tertiary` | `#636A76` ✅ | `#9CA3AF` | eyebrow・ヒント（Light 4.73:1） |
-| `--bg-primary` | `#EEF2F7` | `#0B1021` | アンビエント背景ベース |
+| `--text-primary` | `oklch(0.267 0.029 256)` | `oklch(0.964 0.002 247)` | 本文・見出し |
+| `--text-secondary` | `oklch(0.406 0.013 255)` ✅ | `oklch(0.704 0.005 286)` | メタ情報・ラベル（Light 5.94:1） |
+| `--text-tertiary` | `oklch(0.461 0.014 254)` ✅ | `oklch(0.707 0.022 261)` | eyebrow・ヒント（Light 4.73:1） |
+| `--bg-primary` | `oklch(0.954 0.008 240)` | `oklch(0.150 0.041 268)` | アンビエント背景ベース |
 
 ### Glass Surface
 
-- Card: `rgba(255, 255, 255, 0.50)` + `blur(12px)`（カード・ピル共通の中央値）
-- Border: `rgba(255, 255, 255, 0.70)`
-- Dark card: `rgba(30, 30, 35, 0.50)` + border `rgba(255, 255, 255, 0.10)`
+- **Light card**: `rgba(255, 255, 255, 0.50)` + `blur(12px)`（白の透過なので rgba を維持）
+- **Light border**: `rgba(255, 255, 255, 0.70)`
+- **Dark card**: `oklch(0.249 0.005 286 / 0.50)`（色相のあるダークグレーなので OkLCH）
+- **Dark border**: `rgba(255, 255, 255, 0.10)`（白の透過なので rgba を維持）
 - `saturate(180%)` はヘッダー / メニュー等のクローム要素専用（カードには使わない）
 
 ### Ambient Background Field
 
-`#EEF2F7` の上に、径方向グラデを重ねた静的メッシュ：
-- Blue orb: `rgba(219, 234, 254, 0.60)` @ 20% 20%
-- Yellow orb: `rgba(245, 180, 0, 0.14)` @ 80% 10%
-- Green orb: `rgba(209, 250, 229, 0.30)` @ 90% 80%
-- Violet orb: `rgba(237, 233, 254, 0.30)` @ 10% 90%
+`oklch(0.954 0.008 240)` の上に、径方向グラデを 3 球だけ重ねた静的メッシュ。**4 色以上のオーブは AI 系 LP のテンプレ印象を生むため使わない**：
+- Blue orb: `oklch(0.93 0.04 240 / 0.6)` @ 20% 20%
+- Yellow orb: `oklch(0.787 0.158 79 / 0.14)` @ 80% 10%
+- Green orb: `oklch(0.95 0.055 160 / 0.3)` @ 90% 80%
+
+**禁止**: バイオレット／ピンク／マゼンタ系のオーブ追加（`H` で 280–340 帯は使わない）。
 
 ## 3. Typography Rules
 
@@ -73,13 +88,16 @@
 - bg: `--glass-card-bg` / border: `--glass-card-border` / radius: `28px`
 - `backdrop-filter: blur(12px)`（`saturate(180%)` は不要、ヘッダー系専用）
 - shadow (rest): `0 2px 8px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04)` + `inset 0 1px 0 rgba(255,255,255,0.9)`
-- **Hover**: border → `rgba(245, 180, 0, 0.30)`, shadow → elevated, title → `--liquid-primary`
+- **Hover**: border → `oklch(0.787 0.158 79 / 0.30)`, shadow → elevated, title → `--liquid-primary`
 
 ### Primary Button (`.ds-btn-primary`)
-- bg: `linear-gradient(180deg, #FFDD66, #F5B400)` / text: `#1a1400`
+- bg: `linear-gradient(in oklch 180deg, oklch(0.88 0.16 90), oklch(0.787 0.158 79))` / text: `var(--text-on-yellow)`
 - radius: `9999px`, padding: `10px 20px`, weight: 700
-- shadow: `inset 0 1px 0 rgba(255,255,255,0.6)` + `var(--glow-yellow)`
-- **Hover**: `translateY(-1px)` + glow 強化 / **Active**: `scale(0.98)`
+- shadow (rest): `inset 0 1px 0 rgba(255,255,255,0.6)` + `var(--shadow-rest)` のみ（**グローは常時オフ**）
+- **Hover**: `translateY(-1px)` + `var(--shadow-elevated)` / **Active**: `scale(0.98)`
+- **Focus-visible のみ**: `outline` の代わりに `var(--glow-yellow)` を点灯
+
+> **NOTE**: `--glow-yellow` を CTA の rest 状態で常時光らせると AI 系 SaaS LP の典型表現になり、ボタンが "光るオブジェクト" として浮く。あくまで **キーボードフォーカスの可視化** にのみ使う。
 
 ### Nav (Apple Finder-style)
 - コンテナ背景は**透明**。アクティブなアイテムだけが白 pill として浮く
@@ -88,12 +106,12 @@
 
 ### Filter Tag
 - 通常: `border: 1px solid rgba(0,0,0,0.08)`, bg 透明
-- Active: `bg: --liquid-primary` (黄色), `color: --text-on-yellow` (#1A1400)（白文字ではなく濃い茶色 — 黄色背景に白は WCAG 不合格）
+- Active: `bg: --liquid-primary` (黄色), `color: --text-on-yellow`（白文字ではなく濃い茶色 — 黄色背景に白は WCAG 不合格）
 
 ### Category Chip
-- `color: --liquid-primary-accessible`, `bg: rgba(245,180,0,0.10)`, `border: rgba(245,180,0,0.22)`
+- `color: --liquid-primary-accessible`, `bg: oklch(0.787 0.158 79 / 0.10)`, `border: oklch(0.787 0.158 79 / 0.22)`
 - `letter-spacing: 0.08em; text-transform: uppercase; font-size: 10px;`
-- **注意**: `--liquid-primary` (#F5B400) を前景テキストに使うと WCAG 不合格。必ず `--liquid-primary-accessible` を使用すること。
+- **注意**: `--liquid-primary` を前景テキストに使うと WCAG 不合格。必ず `--liquid-primary-accessible` を使用すること。
 
 ### Input (search)
 - bg: `--glass-card-bg`, border: `--glass-card-border`, radius: `9999px`
@@ -121,13 +139,15 @@
 |---|---|---|
 | `shadow-rest` | `0 2px 8px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04)` | カード・入力・ピル（静止時） |
 | `shadow-elevated` | `0 10px 30px -5px rgba(0,0,0,0.10), 0 4px 8px -2px rgba(0,0,0,0.04)` | ホバー・開いたメニュー・ヘッダー |
-| `glow-yellow` | `0 0 0 1px rgba(245,180,0,0.25), 0 8px 24px rgba(245,180,0,0.28)` | Primary CTA 専用 |
+| `glow-yellow` | `0 0 0 1px oklch(0.787 0.158 79 / 0.25), 0 8px 24px oklch(0.787 0.158 79 / 0.28)` | **`:focus-visible` 時のみ** 点灯（rest 状態で常時光らせない） |
 
 **内側ハイライト** (ガラスの厚み): `inset 0 1px 0 rgba(255,255,255,0.9)`、底辺に `inset 0 -1px 0 rgba(0,0,0,0.05)`。
 
 ## 7. Do's and Don'ts
 
 ### Do
+- 色相を持つ値は `oklch()` で書く
+- グラデーションは `linear-gradient(in oklch ...)` のように補間色空間を明示する
 - 背景アンビエントメッシュを必ず敷く
 - カードには **blur + 内側ハイライト** の 2 点セットを守る（`saturate(180%)` はヘッダー系専用）
 - 動きは `cubic-bezier(0.4, 0, 0.2, 1)` (`--ease-liquid`) を基本に
@@ -136,12 +156,16 @@
 - 英字ラベルは大文字（`WORKS` / `ABOUT`）
 
 ### Don't
+- **色相を持つ値に `rgb()` / `#RRGGBB` を新規導入しない**（既存箇所も見つけたら oklch 化する）
+- グラデの補間色空間を省略しない（既定は sRGB で中央色がくすむ）
+- **背景メッシュにバイオレット／ピンク／マゼンタ（H=280–340）を入れない**（AI 系 LP のテンプレ配色になる）
+- **背景オーブを 4 球以上重ねない**（多色 mesh は AI スタートアップ LP の量産パターン）
+- **`--glow-yellow` を rest 状態の常時シャドウに使わない**（focus-visible 時のみ点灯）
 - 絵文字を UI 装飾に散りばめる
 - 3D 風アイコン、多色フラットイラスト
 - 派手な色面・原色の大面積使用
 - 手書きイラスト、反復パターン背景
 - 本文以外での下線装飾
-- `FFF1B8` Soft yellow を新規に持ち込まない（`FF375F` Accent は `app/error.module.css` で使用中）
 
 ## 8. Responsive Behavior
 
@@ -155,16 +179,37 @@
 
 ### Quick Color Reference
 ```
-Primary yellow: #F5B400    (key color — backgrounds/borders only, NOT foreground text)
-Vibrant:        #FFBE0A    (link hover, accent — backgrounds only)
-On yellow:      #1A1400    (--text-on-yellow — text on yellow bg, 10.75:1 ✅)
-Accessible amb: #7A5200    (--liquid-primary-accessible light — amber text, 6.06:1 ✅)
-Text primary:   #1F2937    (body, headings — light mode)
-Text secondary: #545B64    (meta — light mode, 5.94:1 ✅)
-Text tertiary:  #636A76    (eyebrow, hint — light mode, 4.73:1 ✅)
-Background:     #EEF2F7    (ambient field base)
-Glass fill:     rgba(255,255,255,0.50)
-Glass border:   rgba(255,255,255,0.70)
+Primary yellow:   oklch(0.787 0.158 79)   (キー — 背景・ボーダー専用、前景テキスト NG)
+Vibrant:          oklch(0.815 0.173 84)   (ホバー — 背景専用)
+On yellow:        oklch(0.152 0.018 79)   (--text-on-yellow — 黄色背景上のテキスト 10.75:1 ✅)
+Accessible amber: oklch(0.407 0.087 64)   (--liquid-primary-accessible light — 前景テキスト 6.06:1 ✅)
+Text primary:     oklch(0.267 0.029 256)  (本文・見出し — Light)
+Text secondary:   oklch(0.406 0.013 255)  (メタ — Light 5.94:1 ✅)
+Text tertiary:    oklch(0.461 0.014 254)  (eyebrow — Light 4.73:1 ✅)
+Background:       oklch(0.954 0.008 240)  (アンビエントベース)
+Accent (error):   oklch(0.65 0.227 17)    (--liquid-accent エラー画面のみ)
+Glass fill:       rgba(255,255,255,0.50)  (白の透過は rgba 維持)
+Glass border:     rgba(255,255,255,0.70)
+```
+
+### グラデーション・派生色のレシピ
+
+```css
+/* 補間色空間を必ず明示 */
+.hero {
+  background-image: linear-gradient(
+    in oklch 90deg,
+    oklch(0.787 0.158 79),
+    oklch(0.815 0.173 84)
+  );
+  background-clip: text;
+  color: transparent;
+}
+
+/* 既存色から派生 — Relative Color Syntax */
+.hover {
+  background: oklch(from var(--liquid-primary) calc(l + 0.05) c h);
+}
 ```
 
 ### Ready-to-use Prompts

--- a/app/contact/page.module.css
+++ b/app/contact/page.module.css
@@ -79,7 +79,7 @@
 
 .email {
   background: var(--liquid-primary);
-  box-shadow: 0 2px 8px oklch(0.787 0.158 79 / 30%);
+  box-shadow: 0 2px 8px oklch(0.787 0.158 79 / 0.30);
 }
 
 .x {

--- a/app/contact/page.module.css
+++ b/app/contact/page.module.css
@@ -79,20 +79,20 @@
 
 .email {
   background: var(--liquid-primary);
-  box-shadow: 0 2px 8px rgb(245 180 0 / 30%);
+  box-shadow: 0 2px 8px oklch(0.787 0.158 79 / 30%);
 }
 
 .x {
-  background: #1f2937;
+  background: oklch(0.267 0.029 256);
 }
 
 [data-theme="dark"] .x {
-  background: #f5f5f7;
-  color: #0b1021;
+  background: oklch(0.964 0.002 247);
+  color: oklch(0.150 0.041 268);
 }
 
 .linkedin {
-  background: #0a66c2;
+  background: oklch(0.508 0.166 250);
 }
 
 /* Card Body */

--- a/app/entry/[slug]/page.module.css
+++ b/app/entry/[slug]/page.module.css
@@ -3,8 +3,8 @@
   padding: clamp(var(--space-md), 4vw, var(--space-2xl));
   padding-top: calc(64px + var(--space-lg));
   background:
-    radial-gradient(circle at 20% 20%, rgb(77 96 255 / 8%), transparent 30%),
-    radial-gradient(circle at 80% 10%, rgb(255 179 71 / 8%), transparent 30%),
+    radial-gradient(circle at 20% 20%, oklch(0.55 0.226 268 / 8%), transparent 30%),
+    radial-gradient(circle at 80% 10%, oklch(0.795 0.16 70 / 8%), transparent 30%),
     color-mix(in srgb, var(--bg-primary) 92%, transparent);
 }
 

--- a/app/features/layout/Header/Header.module.css
+++ b/app/features/layout/Header/Header.module.css
@@ -80,7 +80,7 @@
   flex-shrink: 0;
   border-radius: 10px;
   background: var(--liquid-primary);
-  box-shadow: 0 4px 12px rgb(245 180 0 / 30%);
+  box-shadow: 0 4px 12px oklch(0.787 0.158 79 / 30%);
 }
 
 .avatar img {

--- a/app/features/posts/ArticleCard/ArticleCard.module.css
+++ b/app/features/posts/ArticleCard/ArticleCard.module.css
@@ -212,7 +212,7 @@
 /* Dark Mode Specific Adjustments - Handled by LiquidGlassBox */
 
 [data-theme="dark"] .thumbnailContain {
-  background: rgb(240 240 245 / 80%);
+  background: oklch(0.954 0.002 286 / 80%);
 }
 
 [data-theme="dark"] .thumbnailOverlay {

--- a/app/features/talks/UpcomingTalks/UpcomingTalks.module.css
+++ b/app/features/talks/UpcomingTalks/UpcomingTalks.module.css
@@ -31,12 +31,12 @@
   border-radius: var(--radius-full);
   animation: pulse 2.4s var(--ease-liquid) infinite;
   background: var(--liquid-primary);
-  box-shadow: 0 0 0 4px oklch(0.787 0.158 79 / 18%);
+  box-shadow: 0 0 0 4px oklch(0.787 0.158 79 / 0.18);
 }
 
 @keyframes pulse {
-  0%, 100% { box-shadow: 0 0 0 4px oklch(0.787 0.158 79 / 18%); }
-  50% { box-shadow: 0 0 0 8px oklch(0.787 0.158 79 / 5%); }
+  0%, 100% { box-shadow: 0 0 0 4px oklch(0.787 0.158 79 / 0.18); }
+  50% { box-shadow: 0 0 0 8px oklch(0.787 0.158 79 / 0.05); }
 }
 
 .eyebrow {

--- a/app/features/talks/UpcomingTalks/UpcomingTalks.module.css
+++ b/app/features/talks/UpcomingTalks/UpcomingTalks.module.css
@@ -31,12 +31,12 @@
   border-radius: var(--radius-full);
   animation: pulse 2.4s var(--ease-liquid) infinite;
   background: var(--liquid-primary);
-  box-shadow: 0 0 0 4px rgb(245 180 0 / 18%);
+  box-shadow: 0 0 0 4px oklch(0.787 0.158 79 / 18%);
 }
 
 @keyframes pulse {
-  0%, 100% { box-shadow: 0 0 0 4px rgb(245 180 0 / 18%); }
-  50% { box-shadow: 0 0 0 8px rgb(245 180 0 / 5%); }
+  0%, 100% { box-shadow: 0 0 0 4px oklch(0.787 0.158 79 / 18%); }
+  50% { box-shadow: 0 0 0 8px oklch(0.787 0.158 79 / 5%); }
 }
 
 .eyebrow {

--- a/app/styles/globals.css
+++ b/app/styles/globals.css
@@ -2,38 +2,38 @@
 
 @layer base {
   :root {
-    /* Liquid Glass Color System - Light Mode */
-    --liquid-primary: #f5b400;
-    --liquid-primary-vibrant: #ffbe0a;
-    --liquid-primary-dark: #c98a00;
-    --liquid-accent: #ff375f;
+    /* Liquid Glass Color System - Light Mode
+       色相を持つ値は oklch() で記述。L=Lightness 0-1, C=Chroma 0-~0.4, H=Hue 0-360 */
+    --liquid-primary: oklch(0.787 0.158 79);
+    --liquid-primary-vibrant: oklch(0.815 0.173 84);
+    --liquid-primary-dark: oklch(0.645 0.139 71);
+    --liquid-accent: oklch(0.65 0.227 17);
 
-    /* Glass Material Colors */
+    /* Glass Material Colors（白の透過は rgba のまま — ガラス面の素材表現） */
     --glass-bg-medium: rgba(255, 255, 255, 0.5);
     --glass-bg-strong: rgba(255, 255, 255, 0.85);
     --glass-border: rgba(255, 255, 255, 0.8);
 
-    /* Background */
-    --bg-primary: #eef2f7;
-    --bg-gradient-1: rgba(219, 234, 254, 0.6);
-    --bg-gradient-2: rgba(209, 250, 229, 0.3);
-    --bg-gradient-3: rgba(237, 233, 254, 0.3);
-    --bg-orb-1: rgba(245, 180, 0, 0.14);
+    /* Background — 3 オーブ構成（紫を排除して AI mesh テンプレ感を回避） */
+    --bg-primary: oklch(0.954 0.008 240);
+    --bg-gradient-1: oklch(0.93 0.04 240 / 0.6);
+    --bg-gradient-2: oklch(0.95 0.055 160 / 0.3);
+    --bg-orb-1: oklch(0.787 0.158 79 / 0.14);
 
     /* Text Colors */
-    --text-primary: #1f2937;
-    --text-secondary: #545b64; /* WCAG AA on light bg: was #6b7280 (4.16:1 ❌) → 5.94:1 ✅ */
-    --text-tertiary: #636a76; /* WCAG AA on light bg: was #9ca3af (2.4:1 ❌) → 4.73:1 ✅ */
-    --text-inverse: #ffffff;
-    --text-on-yellow: #1a1400;
-    --liquid-primary-accessible: #7a5200; /* WCAG AA for small text on light bg: 6.06:1 ✅ */
+    --text-primary: oklch(0.267 0.029 256);
+    --text-secondary: oklch(0.406 0.013 255); /* WCAG AA on light bg: 5.94:1 ✅ */
+    --text-tertiary: oklch(0.461 0.014 254); /* WCAG AA on light bg: 4.73:1 ✅ */
+    --text-inverse: oklch(1 0 0);
+    --text-on-yellow: oklch(0.152 0.018 79);
+    --liquid-primary-accessible: oklch(0.407 0.087 64); /* WCAG AA for small text on light bg: 6.06:1 ✅ */
 
-    /* Specular Highlights */
+    /* Specular Highlights（白の鏡面ハイライトは rgba を維持） */
     --highlight-top: rgba(255, 255, 255, 0.9);
     --highlight-edge: rgba(255, 255, 255, 0.6);
 
     /* Header */
-    --header-bg: rgba(238, 242, 247, 0.55);
+    --header-bg: oklch(0.954 0.008 240 / 0.55);
     --header-border: rgba(255, 255, 255, 0.75);
     --header-highlight-inset: rgba(255, 255, 255, 0.9);
     --header-shadow-inset: rgba(255, 255, 255, 0.2);
@@ -54,7 +54,7 @@
     --glass-card-bg: rgba(255, 255, 255, 0.5);
     --glass-card-border: rgba(255, 255, 255, 0.7);
     --glass-card-hover-bg: rgba(255, 255, 255, 0.7);
-    --glass-card-hover-border: rgba(245, 180, 0, 0.3);
+    --glass-card-hover-border: oklch(0.787 0.158 79 / 0.3);
 
     /* Animation Timing */
     --ease-liquid: cubic-bezier(0.4, 0.0, 0.2, 1);
@@ -79,44 +79,43 @@
     --radius-xl: 36px;
     --radius-full: 9999px;
 
-    /* Elevation — unified 2-tier + CTA glow */
+    /* Elevation — unified 2-tier + CTA glow（黒の影は rgba を維持） */
     --shadow-rest: 0 2px 8px rgba(0, 0, 0, 0.06), 0 1px 2px rgba(0, 0, 0, 0.04);
     --shadow-elevated: 0 10px 30px -5px rgba(0, 0, 0, 0.1), 0 4px 8px -2px rgba(0, 0, 0, 0.04);
-    --glow-yellow: 0 0 0 1px rgba(245, 180, 0, 0.25), 0 8px 24px rgba(245, 180, 0, 0.28);
+    --glow-yellow: 0 0 0 1px oklch(0.787 0.158 79 / 0.25), 0 8px 24px oklch(0.787 0.158 79 / 0.28);
   }
 
   [data-theme="dark"] {
     /* Liquid Glass Color System - Dark Mode */
-    --liquid-primary: #f5b400;
-    --liquid-primary-vibrant: #ffbe0a;
-    --liquid-primary-dark: #c98a00;
-    --liquid-accent: #ff375f;
+    --liquid-primary: oklch(0.787 0.158 79);
+    --liquid-primary-vibrant: oklch(0.815 0.173 84);
+    --liquid-primary-dark: oklch(0.645 0.139 71);
+    --liquid-accent: oklch(0.65 0.227 17);
 
-    /* Glass Material Colors */
-    --glass-bg-medium: rgba(30, 30, 35, 0.5);
-    --glass-bg-strong: rgba(30, 30, 35, 0.85);
+    /* Glass Material Colors（暗いガラス面は色相付きなので oklch 化） */
+    --glass-bg-medium: oklch(0.249 0.005 286 / 0.5);
+    --glass-bg-strong: oklch(0.249 0.005 286 / 0.85);
     --glass-border: rgba(255, 255, 255, 0.15);
 
-    /* Background */
-    --bg-primary: #0b1021;
-    --bg-gradient-1: rgba(30, 58, 138, 0.3);
-    --bg-gradient-2: rgba(88, 28, 135, 0.15);
-    --bg-gradient-3: rgba(30, 64, 100, 0.2);
-    --bg-orb-1: rgba(245, 180, 0, 0.06);
+    /* Background — 3 オーブ構成（紫 H=305 を青系に置き換え、AI 配色を回避） */
+    --bg-primary: oklch(0.150 0.041 268);
+    --bg-gradient-1: oklch(0.342 0.142 264 / 0.3);
+    --bg-gradient-2: oklch(0.345 0.066 244 / 0.2);
+    --bg-orb-1: oklch(0.787 0.158 79 / 0.06);
 
     /* Text Colors */
-    --text-primary: #f5f5f7;
-    --text-secondary: #a1a1a6;
-    --text-tertiary: #9ca3af;
-    --text-inverse: #000000;
-    --liquid-primary-accessible: #c98a00; /* standard amber - passes on dark bg */
+    --text-primary: oklch(0.964 0.002 247);
+    --text-secondary: oklch(0.704 0.005 286);
+    --text-tertiary: oklch(0.707 0.022 261);
+    --text-inverse: oklch(0 0 0);
+    --liquid-primary-accessible: oklch(0.645 0.139 71); /* standard amber - passes on dark bg */
 
     /* Specular Highlights */
     --highlight-top: rgba(255, 255, 255, 0.2);
     --highlight-edge: rgba(255, 255, 255, 0.1);
 
     /* Header */
-    --header-bg: rgba(11, 16, 33, 0.65);
+    --header-bg: oklch(0.150 0.041 268 / 0.65);
     --header-border: rgba(255, 255, 255, 0.1);
     --header-highlight-inset: rgba(255, 255, 255, 0.08);
     --header-shadow-inset: rgba(255, 255, 255, 0.02);
@@ -134,10 +133,10 @@
     --active-pill-highlight: rgba(255, 255, 255, 0.2);
 
     /* Glass Card */
-    --glass-card-bg: rgba(30, 30, 35, 0.5);
+    --glass-card-bg: oklch(0.249 0.005 286 / 0.5);
     --glass-card-border: rgba(255, 255, 255, 0.1);
-    --glass-card-hover-bg: rgba(30, 30, 35, 0.7);
-    --glass-card-hover-border: rgba(245, 180, 0, 0.3);
+    --glass-card-hover-bg: oklch(0.249 0.005 286 / 0.7);
+    --glass-card-hover-border: oklch(0.787 0.158 79 / 0.3);
 
     /* Elevation — deeper shadows against dark ambient */
     --shadow-rest: 0 2px 8px rgba(0, 0, 0, 0.3), 0 1px 2px rgba(0, 0, 0, 0.2);
@@ -200,7 +199,6 @@
       radial-gradient(ellipse at 20% 20%, var(--bg-gradient-1) 0px, transparent 50%),
       radial-gradient(ellipse at 80% 10%, var(--bg-orb-1) 0px, transparent 45%),
       radial-gradient(ellipse at 90% 80%, var(--bg-gradient-2) 0px, transparent 50%),
-      radial-gradient(ellipse at 10% 90%, var(--bg-gradient-3) 0px, transparent 50%),
       var(--bg-primary);
     background-size: cover;
   }
@@ -237,7 +235,7 @@
   }
 
   ::-webkit-scrollbar-thumb:hover {
-    background: rgba(245, 180, 0, 0.5);
+    background: oklch(0.787 0.158 79 / 0.5);
   }
 }
 


### PR DESCRIPTION
## Summary

- 色相を持つすべての値を `oklch()` に移行（globals.css と各 module.css）。白／黒の透過オーバーレイは `rgba()` のまま維持
- `DESIGN.md` に **§0 Color Notation Policy** を追加し、OkLCH 必須・補間色空間の明示・派生色生成のレシピを文書化
- アンビエントメッシュ背景を 4 球 → 3 球に削減し、紫オーブ（H=290 light / H=305 dark）を排除（AI 系 LP のテンプレ感を回避）
- `--glow-yellow` を Primary Button の rest 状態から外し、`:focus-visible` 限定の表現に降格

## Why

参照デモ（[20260514-findy-css/demo/3_ai-gradient-text/2_oklch-vs-srgb](https://github.com/tonkotsuboy/20260514-findy-css/tree/main/demo/3_ai-gradient-text/2_oklch-vs-srgb)）に合わせ、知覚的に均等な OkLCH を色記法のデフォルトに固定。`oklch(from var(--base) calc(l + 0.1) c h)` で派生色を CSS だけで生成できるようになり、グラデの中央色もくすまない。

合わせて `ui-skills` でレビューし、AI 量産 UI の典型表現（多色 mesh・常時グロー）を `DESIGN.md` の Don't に明文化して再発を防いでいる。

## Test plan

- [ ] `pnpm dev` でライト／ダークモードを切り替え、背景メッシュの色味が崩れていないか目視確認
- [ ] Primary Button が rest 状態でグローしないこと、Tab フォーカス時に黄色グローが点灯することを確認
- [ ] コンタクト・記事一覧・記事詳細・トーク一覧・ヘッダーの各ページで色の劣化がないか確認
- [ ] `pnpm lint:css:fix` を実行（ローカルに node_modules がある環境で）

🤖 Generated with [Claude Code](https://claude.com/claude-code)