### PR TITLE
fix: render nav active state on the server and add hover animation

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -116,7 +116,7 @@ const interviews = [
 const AboutPage: NextPage = () => {
   return (
     <div className={styles.shell}>
-      <Header />
+      <Header currentPath="/about" />
       <main id="main-content" className={styles.main}>
         <div className={styles.page}>
           {/* Profile Hero */}

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -61,7 +61,7 @@ const contacts = [
 const ContactPage: NextPage = () => {
   return (
     <div className={styles.shell}>
-      <Header />
+      <Header currentPath="/contact" />
       <main id="main-content" className={styles.main}>
         <div className={styles.page}>
           <div className={styles.hero}>

--- a/app/entry/[slug]/page.tsx
+++ b/app/entry/[slug]/page.tsx
@@ -102,7 +102,7 @@ const Page = async ({ params }: Params) => {
 
   return (
     <>
-      <Header />
+      <Header currentPath="/" />
       <main className={styles.surface}>
         <EntryMeta
           date={post.date}

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -11,7 +11,7 @@ export default function ErrorPage({
 }) {
   return (
     <div className={styles.shell}>
-      <Header />
+      <Header currentPath="" />
       <main id="main-content" className={styles.main}>
         <div className={styles.page}>
           <p className={styles.code}>Error</p>

--- a/app/features/layout/Header/Header.module.css
+++ b/app/features/layout/Header/Header.module.css
@@ -43,7 +43,7 @@
   flex-shrink: 0;
   border-radius: 10px;
   background: var(--liquid-primary);
-  box-shadow: 0 4px 12px oklch(0.787 0.158 79 / 30%);
+  box-shadow: 0 4px 12px oklch(78.7% 0.158 79deg / 30%);
 }
 
 .avatar img {
@@ -84,11 +84,20 @@
   font-weight: 500;
   text-align: center;
   text-decoration: none;
+  transition:
+    background 0.2s var(--ease-liquid),
+    color 0.2s var(--ease-liquid);
   white-space: nowrap;
 }
 
 .navLink:hover {
-  color: var(--text-secondary);
+  background: var(--glass-card-bg);
+  color: var(--text-primary);
+}
+
+.navLink:focus-visible {
+  outline: 2px solid var(--liquid-primary);
+  outline-offset: 2px;
 }
 
 .navLinkActive {
@@ -96,6 +105,10 @@
   box-shadow: var(--shadow-rest);
   color: var(--text-primary);
   font-weight: 700;
+}
+
+.navLinkActive:hover {
+  background: var(--active-pill-bg);
 }
 
 /* Actions */

--- a/app/features/layout/Header/Header.stories.tsx
+++ b/app/features/layout/Header/Header.stories.tsx
@@ -6,12 +6,6 @@ const meta = {
   component: Header,
   parameters: {
     layout: "fullscreen",
-    nextjs: {
-      appDirectory: true,
-      navigation: {
-        pathname: "/",
-      },
-    },
   },
   title: "Features/Header",
 } satisfies Meta<typeof Header>;
@@ -20,26 +14,20 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const WorksActive: Story = {
+  args: {
+    currentPath: "/",
+  },
+};
 
 export const AboutActive: Story = {
-  parameters: {
-    nextjs: {
-      appDirectory: true,
-      navigation: {
-        pathname: "/about",
-      },
-    },
+  args: {
+    currentPath: "/about",
   },
 };
 
 export const ContactActive: Story = {
-  parameters: {
-    nextjs: {
-      appDirectory: true,
-      navigation: {
-        pathname: "/contact",
-      },
-    },
+  args: {
+    currentPath: "/contact",
   },
 };

--- a/app/features/layout/Header/Header.tsx
+++ b/app/features/layout/Header/Header.tsx
@@ -13,13 +13,17 @@ type NavLinkItem = {
   label: string;
 }
 
+type HeaderProps = {
+  currentPath: string;
+}
+
 const navLinks: NavLinkItem[] = [
   { href: "/", label: "WORKS" },
   { href: "/about", label: "ABOUT" },
   { href: "/contact", label: "CONTACT" },
 ];
 
-export const Header: FC = () => {
+export const Header: FC<HeaderProps> = ({ currentPath }) => {
   return (
     <header className={styles.header}>
       <div className={styles.headerInner}>
@@ -40,7 +44,12 @@ export const Header: FC = () => {
         {/* Nav */}
         <nav className={styles.nav} aria-label="メインナビゲーション">
           {navLinks.map((link: NavLinkItem) => (
-            <NavLink key={link.href} href={link.href} label={link.label} />
+            <NavLink
+              key={link.href}
+              href={link.href}
+              isActive={currentPath === link.href}
+              label={link.label}
+            />
           ))}
         </nav>
 

--- a/app/features/layout/Header/NavLink.tsx
+++ b/app/features/layout/Header/NavLink.tsx
@@ -1,8 +1,5 @@
-"use client";
-
 import clsx from "clsx";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
 
 import styles from "./Header.module.css";
 
@@ -10,16 +7,16 @@ import type { FC } from "react";
 
 type NavLinkProps = {
   href: string;
+  isActive: boolean;
   label: string;
 }
 
-export const NavLink: FC<NavLinkProps> = ({ href, label }) => {
-  const pathname = usePathname();
-
+export const NavLink: FC<NavLinkProps> = ({ href, isActive, label }) => {
   return (
     <Link
       href={href}
-      className={clsx(styles.navLink, pathname === href && styles.navLinkActive)}
+      aria-current={isActive ? "page" : undefined}
+      className={clsx(styles.navLink, isActive && styles.navLinkActive)}
     >
       {label}
     </Link>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -13,7 +13,7 @@ export const metadata: Metadata = {
 export default function NotFound() {
   return (
     <div className={styles.shell}>
-      <Header />
+      <Header currentPath="" />
       <main id="main-content" className={styles.main}>
         <div className={styles.page}>
           <p className={styles.code}>404</p>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -32,7 +32,7 @@ const HomePage: FC = () => {
 
   return (
     <div className={styles.root}>
-      <Header />
+      <Header currentPath="/" />
       <main id="main-content" className={styles.main}>
         <h1 className={styles.visuallyHidden}>鹿野壮のポートフォリオ - WORKS</h1>
         <UpcomingTalks talks={upcomingTalks} />


### PR DESCRIPTION
## Summary

- `NavLink` relied on `usePathname()`, which returns `null` during static prerendering. On `kano.codes/` the WORKS pill therefore did not light up until client-side hydration finished.
- Each page now passes its own `currentPath` to `<Header>`, so the active state is baked into the SSG HTML. `NavLink` becomes a Server Component and gains `aria-current="page"`.
- Nav links picked up a hover affordance to match the other chrome-layer pills (`ThemeToggle`): 200ms `background` + `color` transition with `--ease-liquid`, hover background uses `--glass-card-bg` (matches the "Nav Hover" spec in `DESIGN.md`). Active items keep their background on hover for a Finder-style "no echo on the current item" feel, and a `:focus-visible` outline is added for keyboard users.

## Why

`usePathname()` is documented to be unavailable during static rendering, and any solution that reads it on the server (e.g. `headers()` in a layout) would opt the whole tree out of ISR. Passing `currentPath` from each `page.tsx` keeps the page statically renderable and lets the active class ship in the initial HTML.

## Test plan

- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm exec stylelint app/features/layout/Header/Header.module.css`
- [x] `pnpm test` (vitest, 22 passed)
- [x] Manual: visited `/` and `/about` locally — active pill renders on first paint
- [ ] CI / Chromatic