### PR TITLE
chore: align with Next.js App Router best practices

### DIFF
--- a/app/entry/[slug]/page.tsx
+++ b/app/entry/[slug]/page.tsx
@@ -19,8 +19,8 @@ import type { Metadata } from "next";
 
 import { posts } from "@/.velite";
 
-export const dynamic = "force-static";
 export const revalidate = 3600;
+export const dynamicParams = false;
 
 export function generateStaticParams() {
   return posts

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,14 +1,20 @@
 "use client";
 
+import { useEffect } from "react";
+
 import styles from "./error.module.css";
 import { Header } from "./features/layout/Header";
 
-export default function ErrorPage({
-  reset,
-}: {
+type ErrorPageProps = {
   error: Error & { digest?: string };
   reset: () => void;
-}) {
+};
+
+export default function ErrorPage({ error, reset }: ErrorPageProps) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
   return (
     <div className={styles.shell}>
       <Header currentPath="" />

--- a/app/feed.xml/route.ts
+++ b/app/feed.xml/route.ts
@@ -7,6 +7,9 @@ import { toRfc2822 } from "./lib/toRfc2822";
 
 import { posts } from "@/.velite";
 
+export const dynamic = "force-static";
+export const revalidate = 3600;
+
 const feedUrl = `${SiteUrl}/feed.xml`;
 
 function resolveLink(post: {

--- a/app/global-error.module.css
+++ b/app/global-error.module.css
@@ -1,0 +1,10 @@
+.fallback {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  gap: 16px;
+  min-block-size: 100dvh;
+  text-align: center;
+}

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useEffect } from "react";
+
+import "./styles/globals.css";
+import styles from "./global-error.module.css";
+
+type GlobalErrorProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function GlobalError({ error, reset }: GlobalErrorProps) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <html lang="ja">
+      <body>
+        <main id="main-content" role="alert" className={styles.fallback}>
+          <h1>問題が発生しました</h1>
+          <p>ページの読み込み中にエラーが発生しました。もう一度お試しください。</p>
+          <button type="button" onClick={reset}>
+            もう一度試す
+          </button>
+        </main>
+      </body>
+    </html>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -40,7 +40,6 @@ export const metadata: Metadata = {
     },
   },
   description: basicDescription,
-  manifest: "/manifest.webmanifest",
   metadataBase: new URL(SiteUrl),
   openGraph: {
     description: basicDescription,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,3 @@
-import { type FC, Suspense } from "react";
-
 import { basicDescription, SiteUrl } from "./constants";
 import { Footer } from "./features/layout/Footer";
 import { Header } from "./features/layout/Header";
@@ -11,6 +9,7 @@ import styles from "./page.module.css";
 
 import type { Post } from "@/.velite";
 import type { Metadata } from "next";
+import type { FC } from "react";
 
 import { posts, talks } from "@/.velite";
 
@@ -36,9 +35,7 @@ const HomePage: FC = () => {
       <main id="main-content" className={styles.main}>
         <h1 className={styles.visuallyHidden}>鹿野壮のポートフォリオ - WORKS</h1>
         <UpcomingTalks talks={upcomingTalks} />
-        <Suspense fallback={null}>
-          <ArticleGrid posts={publishedPosts} />
-        </Suspense>
+        <ArticleGrid posts={publishedPosts} />
       </main>
       <Footer />
     </div>


### PR DESCRIPTION
## Summary

A small audit pass against the App Router docs in \`.next-docs\`. No user-visible behavior changes; the goal is to remove dead code, drop redundant declarations, and bring the error boundaries in line with the official patterns.

## What changed

### Error boundaries

- \`app/error.tsx\` was discarding the \`error\` prop. Now it forwards the failure to \`console.error\` via \`useEffect\`, matching the Next.js [error.js example](https://nextjs.org/docs/app/api-reference/file-conventions/error). That gives us a single place to plug in a reporting service later.
- Added \`app/global-error.tsx\` as the last-resort boundary when the root layout itself throws. It defines its own \`<html>\`/\`<body>\` as required, imports \`globals.css\` for base typography, and uses a CSS Module instead of inline styles (matches the project's no-inline-styles rule).

### Route segment config

- \`app/feed.xml/route.ts\`: added \`export const dynamic = "force-static"\` + \`revalidate = 3600\`. The feed depends only on Velite data, so it can be statically prerendered and revalidated on the same cadence as the posts themselves rather than relying solely on \`Cache-Control\` headers.
- \`app/entry/[slug]/page.tsx\`: dropped \`dynamic = "force-static"\` (redundant alongside \`generateStaticParams\` + \`revalidate\`) and added \`dynamicParams = false\` to make "only pre-built slugs are valid, others 404" explicit at the segment-config level — accurate semantics for a blog whose post set is fully known at build time via Velite.

### Dead code / redundant declarations

- \`app/page.tsx\`: removed the \`<Suspense fallback={null}>\` wrapper around \`ArticleGrid\`. \`ArticleGrid\` is a client component that uses only \`useState/useRef/useMemo/useEffect\` — nothing inside it ever suspends, so the fallback was dead code.
- \`app/layout.tsx\`: removed \`metadata.manifest: "/manifest.webmanifest"\`. The [file-based metadata convention](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/manifest) (\`app/manifest.ts\`) already emits the \`<link rel="manifest">\` automatically, so the override duplicates work and risks drifting if the URL changes.

## Not changed (deliberately)

- \`next.config.js\` \`eslint.ignoreDuringBuilds: true\`: CI runs lint separately, and switching this would change build-pipeline trade-offs — out of scope here.
- \`app/features/analytics/GoogleAnalytics\` is unused but kept because we may wire it up later. Worth a separate dead-code pass.
- The \`import { metadata } from "../../layout"\` pattern in \`app/entry/[slug]/page.tsx\` is acceptable: Next.js metadata fields are *replaced* by child segments, not merged, so importing-and-spreading the parent \`openGraph\` is the documented way to inherit \`siteName\`/\`type\`/\`url\` while overriding \`title\`/\`description\`.

## Test plan

- [x] \`pnpm exec tsc --noEmit\`
- [x] \`pnpm exec eslint ...changed-files\`
- [x] \`pnpm exec stylelint app/global-error.module.css\`
- [x] \`pnpm test\` — 22 passed
- [ ] CI / Chromatic