### PR TITLE
fix(header): tighten mobile spacing and unify chrome shadows

### DIFF
--- a/app/features/layout/Header/Header.module.css
+++ b/app/features/layout/Header/Header.module.css
@@ -43,7 +43,7 @@
   flex-shrink: 0;
   border-radius: 10px;
   background: var(--liquid-primary);
-  box-shadow: 0 4px 12px oklch(78.7% 0.158 79deg / 30%);
+  box-shadow: var(--shadow-rest);
 }
 
 .avatar img {
@@ -59,7 +59,8 @@
   letter-spacing: -0.02em;
 }
 
-/* Nav Pill Container — Safari URL bar 風のフラットな半透明 pill */
+/* Nav Pill Container — Safari URL bar 風の半透明 pill。
+   avatar / ThemeToggle と同じ shadow-rest で立体感を揃える。 */
 .nav {
   position: relative;
   display: flex;
@@ -68,6 +69,7 @@
   border: 1px solid var(--nav-pill-border);
   border-radius: var(--radius-full);
   background: var(--nav-pill-bg);
+  box-shadow: var(--shadow-rest);
 }
 
 /* Nav Links */
@@ -131,15 +133,22 @@
   }
 
   .navLink {
-    padding: var(--space-xs) var(--space-sm);
+    padding: var(--space-2xs) var(--space-sm);
     font-size: 0.8125rem;
   }
 }
 
+/* iPhone-class widths: trim chrome height while keeping a comfortable hit area.
+   Apple HIG strict is 44pt; we relax to 36px for a tighter pill (matches Safari's
+   URL bar / Apple.com mobile nav) and stay safely above WCAG 2.5.8 AA (24×24). */
 @media (width <= 480px) {
+  .nav {
+    padding: 3px;
+  }
+
   .navLink {
-    min-height: 44px;
-    padding: var(--space-xs) var(--space-xs);
+    min-height: 36px;
+    padding: var(--space-2xs) var(--space-xs);
     font-size: 0.75rem;
   }
 }


### PR DESCRIPTION
Two polish issues that surfaced from a mobile screenshot of kano.codes.

## 1. Mobile header was too tall and cramped

On iPhone-class widths the nav link declared \`min-height: 44px\`, which ballooned the pill to ~52px and the header to ~68px. The complaint was both "高さが高すぎる" and "左右余白が窮屈" — the second symptom was actually a consequence of the first, since a taller pill takes proportionally more of the horizontal space and squeezes the gaps with the logo and ThemeToggle.

### Reference points

- **Apple HIG / WCAG 2.5.5 (AAA)** asks for 44×44pt touch targets — the strict ceiling.
- **WCAG 2.5.8 (AA)** only requires 24×24px — the floor.
- Safari's own mobile URL-bar pill and Apple.com's iPhone nav both render at ~36pt. That's the practical sweet spot for a text-only pill that is *inside* a bigger chrome row with safe-area padding around it.

### Change

\`\`\`css
@media (width <= 480px) {
  .nav     { padding: 3px; }
  .navLink {
    min-height: 36px;                                /* was 44px */
    padding: var(--space-2xs) var(--space-xs);       /* was --space-xs --space-xs */
    font-size: 0.75rem;
  }
}

@media (width <= 768px) {
  .navLink { padding: var(--space-2xs) var(--space-sm); }  /* was --space-xs --space-sm */
}
\`\`\`

Result: pill ~38px / header ~52px on iPhone-class widths. Touch area is 36×~46px ≈ 1660 sq px — well above the WCAG AA floor, below the HIG strict ceiling, in line with Safari's own pill nav.

## 2. Inconsistent chrome shadows

The three chrome elements were each doing something different:

| Element        | Before                                                       | After             |
|----------------|--------------------------------------------------------------|-------------------|
| Logo avatar    | \`0 4px 12px oklch(.787 .158 79 / .30)\` (yellow glow)         | \`shadow-rest\`     |
| Nav pill       | no shadow                                                    | \`shadow-rest\`     |
| ThemeToggle    | \`shadow-rest\`                                                | (unchanged)       |
| Active nav pill| \`shadow-rest\`                                                | (unchanged)       |

DESIGN.md explicitly flags the "\`--glow-yellow\` at rest" anti-pattern as the AI-SaaS-LP trope. The avatar used a hand-rolled yellow shadow rather than the token, but it broke the same rule. Aligning all three chrome surfaces on \`var(--shadow-rest)\` lets the active nav pill differentiate via its **background color**, not by being the only thing with elevation.

## Verification

- [x] \`pnpm exec tsc --noEmit\` clean
- [x] \`pnpm exec stylelint app/features/layout/Header/Header.module.css\` clean
- [x] Manual: 393px (iPhone 15) and 375px (iPhone SE) in light mode — header sits at ~52px, nav pill and avatar visually peer-level
- [ ] CI / Chromatic