### PR TITLE
fix(a11y): label toggle filters, type the search input, drop unneeded rel

### DIFF
--- a/app/entry/[slug]/page.tsx
+++ b/app/entry/[slug]/page.tsx
@@ -54,7 +54,7 @@ const loadBodyHtml = (slug: string): string => {
     (_m, href: string, text: string) => {
       const escapedHref = escapeHtml(href);
       const escapedText = escapeHtml(text);
-      return `<a class="linkCardStandalone linkCardInline" href="${escapedHref}" target="_blank" rel="noreferrer"><div class="linkThumb"><span>Link</span></div><div class="linkMeta"><div class="linkTitle">${escapedText}</div><div class="linkUrl">${escapedHref}</div></div></a>`;
+      return `<a class="linkCardStandalone linkCardInline" href="${escapedHref}" target="_blank"><div class="linkThumb"><span>Link</span></div><div class="linkMeta"><div class="linkTitle">${escapedText}</div><div class="linkUrl">${escapedHref}</div></div></a>`;
     },
   );
   return replaced;
@@ -125,14 +125,14 @@ const Page = async ({ params }: Params) => {
           {isSlidesAvailable ? (
             <div className={styles.sectionCard}>
               <div className={styles.sectionTitle}>スライド</div>
-              <a className={styles.rawLink} href={post.slides} target="_blank" rel="noreferrer">
+              <a className={styles.rawLink} href={post.slides} target="_blank">
                 {post.slides}
               </a>
             </div>
           ) : null}
 
           {isLinkUrlAvailable ? (
-            <a className={styles.linkCardStandalone} href={post.linkUrl} target="_blank" rel="noreferrer">
+            <a className={styles.linkCardStandalone} href={post.linkUrl} target="_blank">
               <div className={styles.linkThumb}>
                 {isCoverAvailable ? (
                   <Image

--- a/app/features/posts/ArticleGrid/ArticleGrid.module.css
+++ b/app/features/posts/ArticleGrid/ArticleGrid.module.css
@@ -66,6 +66,13 @@
   color: var(--text-tertiary);
 }
 
+/* WebKit/Blink が type="search" に追加するネイティブの×ボタンを抑制。
+   検索は onChange でリアルタイム filter するため、独自 UI と被って見える。
+   空一覧時の「検索をクリア」ボタンで同等の操作は提供している。 */
+.searchBox input::-webkit-search-cancel-button {
+  appearance: none;
+}
+
 .searchBox input:focus {
   border-color: var(--liquid-primary);
   box-shadow: 0 2px 12px rgb(0 0 0 / 6%);

--- a/app/features/posts/ArticleGrid/ArticleGrid.tsx
+++ b/app/features/posts/ArticleGrid/ArticleGrid.tsx
@@ -159,6 +159,7 @@ export const ArticleGrid: FC<Props> = ({ posts }) => {
           <div className={styles.searchBox}>
             <Search size={16} aria-hidden className={styles.searchIcon} />
             <input
+              type="search"
               value={keyword}
               onChange={(event) => {
                 setKeyword(event.target.value);
@@ -169,8 +170,10 @@ export const ArticleGrid: FC<Props> = ({ posts }) => {
           </div>
 
           {allTags.length > 0 && (
-            <div className={styles.tagsContainer}>
+            <div className={styles.tagsContainer} role="group" aria-label="記事フィルター">
               <button
+                type="button"
+                aria-pressed={selectedTag === "all"}
                 className={clsx(styles.tagButton, selectedTag === "all" && styles.tagActive)}
                 onClick={() => {
                   setSelectedTag("all");
@@ -181,6 +184,8 @@ export const ArticleGrid: FC<Props> = ({ posts }) => {
               {allTags.map((tag) => (
                 <button
                   key={tag}
+                  type="button"
+                  aria-pressed={selectedTag === tag}
                   className={clsx(styles.tagButton, selectedTag === tag && styles.tagActive)}
                   onClick={() => {
                     setSelectedTag(tag);

--- a/app/features/talks/UpcomingTalks/UpcomingTalks.tsx
+++ b/app/features/talks/UpcomingTalks/UpcomingTalks.tsx
@@ -24,7 +24,6 @@ const TalkCard: FC<CardProps> = ({ talk }) => {
     <a
       href={talk.registerUrl}
       target="_blank"
-      rel="noreferrer"
       className={clsx(styles.card, hoverStyles.card)}
     >
       {/* Row 1: Thumbnail */}

--- a/next.config.js
+++ b/next.config.js
@@ -18,6 +18,18 @@ const nextConfig = {
           },
         ],
       },
+      {
+        // 現代ブラウザのデフォルトと同じだが、明示することで「rel="noreferrer"
+        // を付けない」という外部リンクポリシー（DESIGN.md §7 /
+        // .claude/rules/react-typescript.md）の前提を可視化する。
+        source: "/(.*)",
+        headers: [
+          {
+            key: "Referrer-Policy",
+            value: "strict-origin-when-cross-origin",
+          },
+        ],
+      },
     ];
   },
   images: {


### PR DESCRIPTION
A second HIG/a11y audit pass against ArticleGrid, plus a follow-up cleanup of `rel="noreferrer"` across the codebase.

## ArticleGrid

### Filter buttons announce no state
The tag filter row is a group of toggle buttons. Two issues:
- The buttons were missing `type="button"`. Outside a `<form>` the HTML default is `submit`, which is the wrong default and a footgun if this gets dropped into a form later.
- They were missing `aria-pressed`. Screen readers had no way to announce which filter was currently selected — the visual yellow pill was carrying all the meaning.

Wrapped the row in `role="group" aria-label="記事フィルター"` so it surfaces as a labeled group of related toggles.

### Search input is `type="text"` instead of `type="search"`
Switched to `type="search"`:
- iOS / mobile keyboards now show a dedicated **Search** return key
- Browsers can surface a built-in clear (×) affordance where supported
- Conveys semantic intent to assistive tech

## `rel="noreferrer"` removal

Earlier drafts of this PR added `rel="noreferrer"` to outbound \`target="_blank"\` links across Footer, About, Contact, and ArticleGrid. **Reversed that decision** and also removed pre-existing `rel="noreferrer"` in UpcomingTalks and the entry/\[slug\] markdown post-processor (3 occurrences).

| Why \`noopener\` is unnecessary | Why \`noreferrer\` is undesirable here |
|---|---|
| Modern browsers (Chrome 88+ / Firefox 79+ / Safari 12.1+) auto-apply \`noopener\` semantics to \`target="_blank"\` anchors. The project's ESLint \`no-restricted-syntax\` rule explicitly rejects spelling it out. | Default \`Referrer-Policy: strict-origin-when-cross-origin\` (Chrome 85+ / Firefox 87+ / Safari 16.4+) already trims the Referer header to origin-only. Suppressing the origin too means the destination's Analytics can no longer see kano.codes referred the visitor — and every outbound link goes to a friendly destination (X / GitHub / Zenn / Qiita / Speaker Deck / book publishers) where that referral signal is **wanted**. |

The new policy is documented in **PR #400** (DESIGN.md §7 Don't + \`.claude/rules/react-typescript.md\`).

## Considered but not done

The audit also raised \`:focus-visible\` rules and \`prefers-reduced-motion\` overrides per component, but checking \`app/styles/globals.css\`:
- Lines 214–220 declare a universal \`:focus-visible { outline: 2px solid var(--liquid-primary); outline-offset: 4px; }\` inside \`@layer components\`
- Lines 259–267 declare a universal \`@media (prefers-reduced-motion: reduce)\` zeroing animation/transition durations across \`*, *::before, *::after\`

So no per-component motion or focus guards are needed — they'd be dead code.

## Test plan

- [x] \`pnpm exec tsc --noEmit\`
- [x] \`pnpm exec eslint <changed files>\` clean
- [x] \`pnpm test\` (22 passed)
- [x] \`pnpm markuplint\` (no findings)
- [ ] CI / Chromatic