### PR TITLE
refactor(ThemeToggle): popoverTarget から commandFor + command へ移行

### DIFF
--- a/app/features/theme/ThemeToggle/ThemeToggle.tsx
+++ b/app/features/theme/ThemeToggle/ThemeToggle.tsx
@@ -26,7 +26,8 @@ export const ThemeToggle: FC = () => {
         type="button"
         className={styles.toggle}
         data-theme={theme}
-        popoverTarget={POPOVER_ID}
+        commandFor={POPOVER_ID}
+        command="toggle-popover"
         aria-haspopup="menu"
         aria-label="テーマを切り替え"
       >
@@ -49,8 +50,8 @@ export const ThemeToggle: FC = () => {
               role="menuitemradio"
               aria-checked={mode === option.value}
               className={styles.menuItem}
-              popoverTarget={POPOVER_ID}
-              popoverTargetAction="hide"
+              commandFor={POPOVER_ID}
+              command="hide-popover"
               onClick={() => setMode(option.value)}
             >
               <option.icon className={styles.menuIcon} size={16} />

--- a/app/types/invoker-commands.d.ts
+++ b/app/types/invoker-commands.d.ts
@@ -1,0 +1,19 @@
+// Invoker Commands API (`command` / `commandFor`) の型拡張。
+// @types/react 19.x 時点ではまだ未対応のため、ButtonHTMLAttributes に
+// プロパティを追加宣言する。仕様が安定し @types/react が追従したら削除可。
+// https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button#command
+import "react";
+
+declare module "react" {
+  interface ButtonHTMLAttributes<T> {
+    command?:
+      | "show-popover"
+      | "hide-popover"
+      | "toggle-popover"
+      | "show-modal"
+      | "close"
+      | "request-close"
+      | `--${string}`;
+    commandFor?: string;
+  }
+}


### PR DESCRIPTION
## Summary

`<button popoverTarget>` + `popoverTargetAction` を、後継の Invoker Commands API（`commandFor` + `command`）に置き換える。

- Popover API 専用属性 → 汎用 API へ移行
- 将来的に `<dialog>` / `<details>` / `<input>` 等を同じ仕組みで操作可能になる
- 動作（クリックでメニュー toggle / 項目クリックで hide）は変わらない

## Changes

| Before | After |
|---|---|
| `popoverTarget={POPOVER_ID}` （トグルボタン、action 省略時の toggle） | `commandFor={POPOVER_ID} command=\"toggle-popover\"` |
| `popoverTarget={POPOVER_ID} popoverTargetAction=\"hide\"` （メニュー項目） | `commandFor={POPOVER_ID} command=\"hide-popover\"` |

@types/react@19.2.14 時点ではまだ `command` / `commandFor` の型定義が含まれていないため、`app/types/invoker-commands.d.ts` で `ButtonHTMLAttributes` を拡張。仕様が安定し型が追従したら削除可。

## References

- https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button#command
- https://open-ui.org/components/invokers.explainer/

## Test plan

- [x] \`npx tsc --noEmit\` でエラーなし
- [x] \`npx eslint app/features/theme/ThemeToggle/ThemeToggle.tsx\` でエラーなし
- [x] \`npx markuplint app/features/theme/ThemeToggle/ThemeToggle.tsx\` でエラーなし
- [ ] Chrome / Safari / Firefox の最新版でトグルボタンクリックでメニュー開閉、項目クリックでメニュー閉じることを確認
- [ ] Storybook でテーマ切り替え動作を目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)