### PR TITLE
fix(UpcomingTalks): タイトルと CTA の余白を整え、カード hover で CTA も黄色化

### DIFF
--- a/app/features/talks/UpcomingTalks/UpcomingTalks.module.css
+++ b/app/features/talks/UpcomingTalks/UpcomingTalks.module.css
@@ -140,11 +140,13 @@
   text-wrap: pretty;
 }
 
-/* Row 4: Footer */
+/* Row 4: Footer
+   タイトル末尾の leading とボタン上端の間に視覚的余白を確保するため、
+   row-gap だけに頼らず padding-top で底上げする */
 .footRow {
   display: flex;
   align-items: center;
-  padding: 0 18px 18px;
+  padding: var(--space-xs) 18px 18px;
 }
 
 .registerBtn {
@@ -159,7 +161,15 @@
   font-weight: 700;
   gap: 5px;
   letter-spacing: 0.02em;
+  transition:
+    background 0.2s var(--ease-liquid),
+    color 0.2s var(--ease-liquid);
   white-space: nowrap;
+}
+
+.card:hover .registerBtn {
+  background: var(--liquid-primary);
+  color: var(--text-on-yellow);
 }
 
 /* Responsive */


### PR DESCRIPTION
## Summary

直近の登壇予定カードで気付いた 2 点を修正。

### 1. タイトル末尾と CTA ボタン上の余白が詰まって見える

`.footRow` が `padding: 0 18px 18px` で `padding-top: 0`。subgrid の `row-gap` (= `var(--space-xs)`) のみが効くが、タイトル側はテキストの leading が下端に効くのに対し、ボタン（`.registerBtn`）は flex item で leading を持たないため、視覚的に「タイトル → ボタン」だけ詰まって見えた。`padding-top: var(--space-xs)` を追加して 8px 上に余白を確保する。

### 2. カードホバー時、CTA だけ黒のまま浮く

カード hover でタイトル色は `--liquid-primary` に変わるが、CTA ボタンの色は据え置きだった。`.card:hover .registerBtn` で背景を `--liquid-primary`、文字色を `--text-on-yellow` に切り替え、`transition` も追加してタイトル色変化と同期させた。

## Test plan

- [ ] `pnpm dev` で TOP ページを開き、Upcoming Talks のカードに hover → ボタンが黄色に切り替わるか確認
- [ ] タイトル 1〜3 行のカードで「タイトル → ボタン」間のスペースが他の行間と揃って見えるか確認
- [ ] 768px 以下で 1 カラム表示にしたときも同様にホバー / 余白が崩れないか確認
- [ ] `prefers-reduced-motion: reduce` でも色変化が破綻しないか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)