### PR TITLE
feat: modern-web-guidance 監査由来のフロントエンド改善（8件）

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -117,7 +117,7 @@ const AboutPage: NextPage = () => {
   return (
     <div className={styles.shell}>
       <Header currentPath="/about" />
-      <main id="main-content" className={styles.main}>
+      <main id="main-content" tabIndex={-1} className={styles.main}>
         <div className={styles.page}>
           {/* Profile Hero */}
           <div className={styles.profileHero}>

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -62,7 +62,7 @@ const ContactPage: NextPage = () => {
   return (
     <div className={styles.shell}>
       <Header currentPath="/contact" />
-      <main id="main-content" className={styles.main}>
+      <main id="main-content" tabIndex={-1} className={styles.main}>
         <div className={styles.page}>
           <div className={styles.hero}>
             <h1 className={styles.title}>Contact</h1>

--- a/app/entry/[slug]/components/EntryCover.tsx
+++ b/app/entry/[slug]/components/EntryCover.tsx
@@ -21,6 +21,7 @@ export const EntryCover: FC<Props> = ({ alt, coverSrc }) => {
         height={630}
         sizes="(max-width: 768px) 100vw, 960px"
         className={styles.coverImage}
+        priority
         unoptimized
       />
     </div>

--- a/app/entry/[slug]/page.module.css
+++ b/app/entry/[slug]/page.module.css
@@ -1,3 +1,28 @@
+/* 読書進捗バー（装飾・JS ゼロ）。スクロール量に応じて scaleX(0→1)。
+   装飾要素なので JSX 側で aria-hidden を付与。Firefox 等 scroll-driven 未対応では
+   .progress にスタイルが当たらず非表示のまま（graceful degradation）。
+   reduced-motion 時は適用しない（globals の universal リセットで満タン固定化されるのを回避）。 */
+@media (prefers-reduced-motion: no-preference) {
+  @supports (animation-timeline: scroll()) {
+    @keyframes growProgress {
+      from {
+        transform: scaleX(0);
+      }
+    }
+
+    .progress {
+      position: fixed;
+      z-index: 200;
+      height: 3px;
+      animation: growProgress auto linear;
+      animation-timeline: scroll();
+      background: linear-gradient(in oklch 90deg, var(--liquid-primary), var(--liquid-primary-vibrant));
+      inset: 0 0 auto;
+      transform-origin: 0 0;
+    }
+  }
+}
+
 .surface {
   min-height: 100vh;
   padding: clamp(var(--space-md), 4vw, var(--space-2xl));

--- a/app/entry/[slug]/page.module.css
+++ b/app/entry/[slug]/page.module.css
@@ -11,6 +11,8 @@
     }
 
     .progress {
+      /* z-index はヘッダー（z-index:100）より前面。読書進捗バーはビューポート最上部に
+         見せる必要があり、背面に置くと全幅ヘッダーに隠れて見えなくなるため意図的。 */
       position: fixed;
       z-index: 200;
       height: 3px;

--- a/app/entry/[slug]/page.tsx
+++ b/app/entry/[slug]/page.tsx
@@ -48,8 +48,10 @@ const loadBodyHtml = (slug: string): string => {
   if (parts.length < 3) {return "";}
   const body = parts.slice(2).join("---\n");
   const htmlString = marked.parse(body) as string;
+  // 横スクロールするコードブロックをキーボードだけで操作できるよう pre をフォーカス可能に（a11y）
+  const withFocusablePre = htmlString.replace(/<pre>/g, '<pre tabindex="0">');
   // 段落単位のリンクをカード風に置き換え
-  const replaced = htmlString.replace(
+  const replaced = withFocusablePre.replace(
     /<p><a href="([^"]+)"[^>]*>(.*?)<\/a><\/p>/g,
     (_m, href: string, text: string) => {
       const escapedHref = escapeHtml(href);
@@ -103,7 +105,8 @@ const Page = async ({ params }: Params) => {
   return (
     <>
       <Header currentPath="/" />
-      <main className={styles.surface}>
+      <main id="main-content" tabIndex={-1} className={styles.surface}>
+        <div className={styles.progress} aria-hidden="true" />
         <EntryMeta
           date={post.date}
           formattedDate={formattedDate}

--- a/app/entry/[slug]/page.tsx
+++ b/app/entry/[slug]/page.tsx
@@ -48,8 +48,10 @@ const loadBodyHtml = (slug: string): string => {
   if (parts.length < 3) {return "";}
   const body = parts.slice(2).join("---\n");
   const htmlString = marked.parse(body) as string;
-  // 横スクロールするコードブロックをキーボードだけで操作できるよう pre をフォーカス可能に（a11y）
-  const withFocusablePre = htmlString.replace(/<pre>/g, '<pre tabindex="0">');
+  // 横スクロールするコードブロックをキーボードだけで操作できるよう pre をフォーカス可能に（a11y）。
+  // 先読み (?=[\s>]) で「<pre」直後が空白か > のときだけ位置マッチ。属性付き <pre class="..."> にも
+  // 対応しつつ <prefetch> 等の別タグ誤マッチを防ぐ。
+  const withFocusablePre = htmlString.replace(/<pre(?=[\s>])/g, '<pre tabindex="0"');
   // 段落単位のリンクをカード風に置き換え
   const replaced = withFocusablePre.replace(
     /<p><a href="([^"]+)"[^>]*>(.*?)<\/a><\/p>/g,

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -18,7 +18,7 @@ export default function ErrorPage({ error, reset }: ErrorPageProps) {
   return (
     <div className={styles.shell}>
       <Header currentPath="" />
-      <main id="main-content" className={styles.main}>
+      <main id="main-content" tabIndex={-1} className={styles.main}>
         <div className={styles.page}>
           <p className={styles.code}>Error</p>
           <h1 className={styles.title}>問題が発生しました</h1>

--- a/app/features/analytics/WebVitals/WebVitals.tsx
+++ b/app/features/analytics/WebVitals/WebVitals.tsx
@@ -14,7 +14,10 @@ export const WebVitals: FC = () => {
     }
 
     window.gtag("event", metric.name, {
-      event_category: "Web Vitals",
+      // useReportWebVitals は Core Web Vitals に加えて Next.js 独自メトリクス
+      // （Next.js-hydration 等。metric.label === "custom"）も発火する。
+      // event_category で両者を分けておくと GA4 側でフィルタしやすい。
+      event_category: metric.label === "web-vital" ? "Web Vitals" : "Next.js custom metric",
       event_label: metric.id,
       non_interaction: true,
       // CLS は小数なので 1000 倍して整数化（GA の value は整数前提）。

--- a/app/features/analytics/WebVitals/WebVitals.tsx
+++ b/app/features/analytics/WebVitals/WebVitals.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useReportWebVitals } from "next/web-vitals";
+
+import type { NextWebVitalsMetric } from "next/app";
+import type { FC } from "react";
+
+// Core Web Vitals（LCP / INP / CLS など）を計測し、gtag があれば GA イベントとして送信する。
+// gtag 未ロード環境では何も送らない（クラッシュしない）。
+export const WebVitals: FC = () => {
+  useReportWebVitals((metric: NextWebVitalsMetric) => {
+    if (typeof window.gtag !== "function") {
+      return;
+    }
+
+    window.gtag("event", metric.name, {
+      event_category: "Web Vitals",
+      event_label: metric.id,
+      non_interaction: true,
+      // CLS は小数なので 1000 倍して整数化（GA の value は整数前提）。
+      value: Math.round(metric.name === "CLS" ? metric.value * 1000 : metric.value),
+    });
+  });
+
+  return null;
+};

--- a/app/features/analytics/WebVitals/index.ts
+++ b/app/features/analytics/WebVitals/index.ts
@@ -1,0 +1,1 @@
+export { WebVitals } from "./WebVitals";

--- a/app/features/talks/UpcomingTalks/UpcomingTalks.tsx
+++ b/app/features/talks/UpcomingTalks/UpcomingTalks.tsx
@@ -14,10 +14,11 @@ function formatDate(dateStr: string): string {
 }
 
 type CardProps = {
+  priority?: boolean;
   talk: Talk;
 }
 
-const TalkCard: FC<CardProps> = ({ talk }) => {
+const TalkCard: FC<CardProps> = ({ priority = false, talk }) => {
   const hasThumbnail = talk.thumbnail.length > 0;
 
   return (
@@ -35,6 +36,7 @@ const TalkCard: FC<CardProps> = ({ talk }) => {
             fill
             className={styles.thumbImg}
             sizes="(max-width: 768px) 100vw, 50vw"
+            priority={priority}
           />
         ) : (
           <div className={styles.thumbPlaceholder} />
@@ -93,8 +95,8 @@ export const UpcomingTalks: FC<Props> = ({ talks }) => {
         </div>
 
         <div className={styles.grid}>
-          {talks.map((talk) => (
-            <TalkCard key={talk.slug} talk={talk} />
+          {talks.map((talk, index) => (
+            <TalkCard key={talk.slug} priority={index === 0} talk={talk} />
           ))}
         </div>
       </div>

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -18,7 +18,7 @@ export default function GlobalError({ error, reset }: GlobalErrorProps) {
   return (
     <html lang="ja">
       <body>
-        <main id="main-content" role="alert" className={styles.fallback}>
+        <main id="main-content" tabIndex={-1} role="alert" className={styles.fallback}>
           <h1>問題が発生しました</h1>
           <p>ページの読み込み中にエラーが発生しました。もう一度お試しください。</p>
           <button type="button" onClick={reset}>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import "./styles/globals.css";
 
 import clsx from "clsx";
 import { Inter, Noto_Sans_JP } from "next/font/google";
+import Script from "next/script";
 
 import {
   basicDescription,
@@ -12,6 +13,7 @@ import {
   TwitterId,
   WithSiteTitle,
 } from "./constants";
+import { WebVitals } from "./features/analytics/WebVitals";
 import { ServiceWorkerRegister } from "./features/pwa/ServiceWorkerRegister";
 import { ThemeProvider } from "./features/theme/ThemeProvider";
 
@@ -92,11 +94,15 @@ export default function RootLayout({
   return (
     <html lang="ja" className={clsx(inter.variable, notoSansJP.variable)} suppressHydrationWarning>
       <body>
+        {/* 描画前にテーマを確定させ FOUC を防ぐ。beforeInteractive で <head> 内に
+            同期実行される。ThemeProvider（useEffect）より先に data-theme を設定。 */}
+        <Script src="/theme-init.js" strategy="beforeInteractive" />
         <a href="#main-content" className="skip-nav">
           メインコンテンツへスキップ
         </a>
         <ThemeProvider>{children}</ThemeProvider>
         <ServiceWorkerRegister />
+        <WebVitals />
       </body>
     </html>
   );

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -14,7 +14,7 @@ export default function NotFound() {
   return (
     <div className={styles.shell}>
       <Header currentPath="" />
-      <main id="main-content" className={styles.main}>
+      <main id="main-content" tabIndex={-1} className={styles.main}>
         <div className={styles.page}>
           <p className={styles.code}>404</p>
           <h1 className={styles.title}>ページが見つかりません</h1>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -32,7 +32,7 @@ const HomePage: FC = () => {
   return (
     <div className={styles.root}>
       <Header currentPath="/" />
-      <main id="main-content" className={styles.main}>
+      <main id="main-content" tabIndex={-1} className={styles.main}>
         <h1 className={styles.visuallyHidden}>鹿野壮のポートフォリオ - WORKS</h1>
         <UpcomingTalks talks={upcomingTalks} />
         <ArticleGrid posts={publishedPosts} />

--- a/app/styles/globals.css
+++ b/app/styles/globals.css
@@ -174,6 +174,12 @@
 
     /* Baseline 2024: 日本語タイポの行頭・行末で約物（句読点・鉤括弧）をぶら下げる */
     hanging-punctuation: first allow-end last;
+
+    /* Baseline 2024: Web フォント読み込み中のフォールバック（system フォント）を
+       主フォントの x-height に合わせて拡縮し、フォント差し替え時の字面ジャンプ
+       （CLS / ちらつき）を抑える。`from-font` で Noto Sans JP のメトリクスを自動採用。
+       未対応ブラウザは無視（デフォルトスケールにフォールバック）。 */
+    font-size-adjust: from-font;
   }
 
   /* Baseline 2024: 本文の最終行が孤立しないように調整 */

--- a/next.config.js
+++ b/next.config.js
@@ -24,6 +24,21 @@ const nextConfig = {
             key: "Referrer-Policy",
             value: "strict-origin-when-cross-origin",
           },
+          // MIME スニッフィング抑止。Content-Type を厳密に解釈させる（破壊リスクほぼゼロ）。
+          {
+            key: "X-Content-Type-Options",
+            value: "nosniff",
+          },
+          // クリックジャッキング防止。kano.codes 自身以外の iframe 埋め込みを禁止。
+          {
+            key: "X-Frame-Options",
+            value: "SAMEORIGIN",
+          },
+          // 不要な強力 API（カメラ・位置情報・マイク）をページ／iframe ともに無効化。
+          {
+            key: "Permissions-Policy",
+            value: "camera=(), geolocation=(), microphone=()",
+          },
         ],
       },
     ];

--- a/public/theme-init.js
+++ b/public/theme-init.js
@@ -1,0 +1,22 @@
+// 描画前にテーマを確定させ、FOUC（ダーク利用者がライトを一瞬見る）を防ぐ。
+// layout.tsx から next/script の beforeInteractive で <head> 内に同期実行される。
+// ロジックは ThemeProvider（storageKey="kano-theme" / light|dark|system）と一致させる。
+(function () {
+  try {
+    var saved = localStorage.getItem("kano-theme");
+    var mode =
+      saved === "light" || saved === "dark" || saved === "system"
+        ? saved
+        : "system";
+    var isDark =
+      mode === "dark" ||
+      (mode === "system" &&
+        window.matchMedia("(prefers-color-scheme: dark)").matches);
+    var theme = isDark ? "dark" : "light";
+    var root = document.documentElement;
+    root.dataset.theme = theme;
+    root.style.colorScheme = theme;
+  } catch (e) {
+    // localStorage 不可（プライベートモード等）でも描画は継続。既定はライト。
+  }
+})();


### PR DESCRIPTION
## 概要

`modern-web-guidance` スキルでの採用棚卸し（`/modern-web-audit.html` 参照）を元に、HTML/CSS/JS/a11y/セキュリティ/パフォーマンスの改善を実装しました。

## 変更内容（8件）

### 必須・バグ修正
- **テーマ FOUC 解消**: `public/theme-init.js` を `next/script` の `beforeInteractive` で読み込み、描画前に `data-theme`/`colorScheme` を確定。ダーク利用者が一瞬ライトを見る問題を解消（ロジックは `ThemeProvider` と一致）。
- **skip-link を機能させる（a11y バグ修正）**: 記事詳細 `entry/[slug]` の `<main>` に `id="main-content"` が無く skip-link が無効だった問題を修正。あわせて全ページの `<main>` に `tabIndex={-1}` を付与（スキップ後にフォーカスが移るように）。

### 推奨
- **LCP 画像に priority**: 記事カバー（`EntryCover`）と直近登壇カードの先頭サムネに `priority`。
- **font-size-adjust: from-font**: Web フォント差し替え時の字面ジャンプ（CLS / ちらつき）を低減。
- **セキュリティ companion ヘッダー**: `X-Content-Type-Options: nosniff` / `X-Frame-Options: SAMEORIGIN` / `Permissions-Policy: camera=(), geolocation=(), microphone=()` を `next.config.js` に追加。

### 任意
- **記事コードブロックの a11y**: marked 出力の `<pre>` に `tabindex="0"`（キーボード横スクロール可能化）。
- **スクロール進捗バー**: 記事詳細に `animation-timeline: scroll()` のバー（JSゼロ・装飾、`aria-hidden`、`@supports`+`prefers-reduced-motion` ガードで graceful degradation）。
- **web-vitals 計測**: `useReportWebVitals` で INP/LCP 等を `gtag` 送信する `WebVitals` コンポーネントを追加。

## 補足
- `GoogleAnalytics` コンポーネントは定義のみで現在どこからも render されていないため、`WebVitals` は `typeof window.gtag === "function"` のガード付き（GA 配置時に自動で送信開始）。

## 検証
- ✅ `tsc --noEmit` / `eslint` / `stylelint`: パス
- ⚠️ `next build`: ローカルのサンドボックスが Google Fonts に接続できず next/font 取得で停止（**環境起因・コード非起因**）。Vercel プレビューでの本番ビルド確認をお願いします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)