### PR TITLE
feat: モダンCSSのDos / Don'ts大全記事を実績に追加

### DIFF
--- a/content/posts/modern-css-dos-donts.md
+++ b/content/posts/modern-css-dos-donts.md
@@ -1,0 +1,14 @@
+---
+title: "GoogleのModern Web Guidanceに学ぶ、モダンCSSのDos / Don'ts大全"
+slug: "modern-css-dos-donts"
+date: "2026-05-21T00:00+09:00"
+published: true
+tags: []
+categories: []
+medium: "執筆記事"
+thumbnail: ""
+slides: ""
+linkUrl: "https://zenn.dev/ubie_dev/articles/modern-css-dos-donts"
+targetUrl: "https://zenn.dev/ubie_dev/articles/modern-css-dos-donts"
+hasDetail: false
+---


### PR DESCRIPTION
## 概要

Zenn記事「GoogleのModern Web Guidanceに学ぶ、モダンCSSのDos / Don'ts大全」を実績（執筆記事）として追加します。

- 記事URL: https://zenn.dev/ubie_dev/articles/modern-css-dos-donts
- 公開日: 2026-05-21

## 変更点

- `content/posts/modern-css-dos-donts.md` を追加
  - `medium: "執筆記事"` / `hasDetail: false` の既存テンプレートに準拠
  - `linkUrl` / `targetUrl` に Zenn 記事 URL を設定

## 確認

- `pnpm velite build` 成功（生成された `.velite/posts.json` に新エントリを確認）
- `pnpm test` 22件すべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)