### PR TITLE
Fix metadata duplication and enhance locale data

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -27,7 +27,8 @@ export const metadata: Metadata = {
     title: `自己紹介${WithSiteTitle}`,
     type: "website",
   },
-  title: `自己紹介${WithSiteTitle}`,
+  // title.template の二重適用を absolute で防ぐ（og/twitter は template 対象外なので連結のまま）
+  title: { absolute: `自己紹介${WithSiteTitle}` },
   twitter: {
     description: aboutDescription,
     images: [ogImageUrl],

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -26,7 +26,8 @@ export const metadata: Metadata = {
     title: `Contact${WithSiteTitle}`,
     type: "website",
   },
-  title: `Contact${WithSiteTitle}`,
+  // title.template の二重適用を absolute で防ぐ（og/twitter は template 対象外なので連結のまま）
+  title: { absolute: `Contact${WithSiteTitle}` },
   twitter: {
     description: contactDescription,
     images: [ogImageUrl],

--- a/app/entry/[slug]/page.tsx
+++ b/app/entry/[slug]/page.tsx
@@ -77,12 +77,17 @@ export const generateMetadata = async ({ params }: Params): Promise<Metadata> =>
     description,
     openGraph: {
       ...metadata.openGraph,
+      authors: ["https://x.com/tonkotsuboy_com"],
       description,
       images: [{ alt: post.title, height: 630, url: ogImage, width: 1200 }],
+      publishedTime: post.date,
       title,
       type: "article",
+      url: `/entry/${slug}`,
     },
-    title,
+    // title は 64 行目で WithSiteTitle 連結済み。layout.tsx の title.template が
+    // 文字列 title に再適用されサフィックスが二重化するのを absolute で防ぐ。
+    title: { absolute: title },
     twitter: {
       ...metadata.twitter,
       description,

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -52,6 +52,7 @@ export const metadata: Metadata = {
         width: 1200,
       },
     ],
+    locale: "ja_JP",
     siteName: SiteTitle,
     title: SiteTitle,
     type: "website",

--- a/content/posts/css_202109.md
+++ b/content/posts/css_202109.md
@@ -5,7 +5,7 @@ date: "2021-09-01T00:00+09:00"
 published: true
 tags: []
 categories: []
-medium: "執筆記事"
+medium: "書籍"
 thumbnail: ""
 slides: ""
 linkUrl: "https://info.nikkeibp.co.jp/media/NSW/atcl/mag/051600042/"

--- a/content/posts/ts-code-recipe.md
+++ b/content/posts/ts-code-recipe.md
@@ -1,7 +1,7 @@
 ---
-title: "『TypeScriptコードレシピ集』を執筆しました。TypeScript/JavaScript逆引き本"
+title: "『TypeScriptコードレシピ集』を執筆しました。TypeScript/JavaScript逆引き入門書"
 slug: "ts-code-recipe"
-date: "2026-05-21T00:00+09:00"
+date: "2026-05-25T00:00+09:00"
 description: "鹿野壮の著書『TypeScriptコードレシピ集』が技術評論社より発売。目的から逆引きできる全14章177レシピ・680ページの入門書で、JavaScript/TypeScriptの基礎から型システム・非同期処理まで初学者〜中級者向けに解説します。"
 published: true
 tags: []

--- a/content/posts/ts-software-design.md
+++ b/content/posts/ts-software-design.md
@@ -5,7 +5,7 @@ date: "2024-04-18T00:00+09:00"
 published: true
 tags: []
 categories: []
-medium: "執筆記事"
+medium: "書籍"
 thumbnail: "/images/og/ts-software-design.webp"
 slides: ""
 linkUrl: "https://gihyo.jp/magazine/SD/archive/2024/202405"


### PR DESCRIPTION
### Description

- Prevent duplication of `title.template` in metadata by ensuring absolute titles.
- Add missing `ja_JP` locale in layout metadata.
- Include additional metadata fields: `authors`, `publishedTime`, and `url`.
- Update medium descriptor to "書籍".
- Adjust `ts-code-recipe` title and date. 

### Checklist

- [ ] Tests have been added or updated (if applicable).
- [ ] Documentation has been updated (if applicable).