### PR TITLE
fix: 記事カバー画像(LCP)にfetchpriority=highを明示

### DIFF
--- a/app/entry/[slug]/components/EntryCover.tsx
+++ b/app/entry/[slug]/components/EntryCover.tsx
@@ -30,6 +30,10 @@ export const EntryCover: FC<Props> = ({ alt, coverSrc }) => {
         sizes="(max-width: 768px) 100vw, 720px"
         className={styles.coverImage}
         priority
+        // Next.js の `priority` は eager 読み込みと preload link は付けるが、
+        // <img> 自体の fetchpriority 属性には反映されない（get-img-props は明示 prop のみ素通し）。
+        // LCP 画像なので fetchpriority="high" を明示し、初期描画を最優先にする。
+        fetchPriority="high"
         unoptimized
         onError={() => setFailed(true)}
       />


### PR DESCRIPTION
## 概要

記事詳細ページの LCP 要素であるカバー画像（`EntryCover`）に `fetchPriority="high"` を明示追加します。

Chrome DevTools / Lighthouse の **LCP request discovery** インサイトで「fetchpriority=high should be applied ❌」が出ていたのを解消します。

## 背景（なぜ `priority` だけでは不十分だったか）

Next.js 16 の `<Image>` のソース（`next/dist/shared/lib/get-img-props.js`）を確認したところ、`priority` が制御するのは次の2つだけでした:

- `loading="eager"`（遅延読み込みを無効化 → 「lazy load not applied ✅」）
- `<link rel="preload">` の注入（→「Request is discoverable ✅」）

一方、実際の `<img fetchpriority>` 属性は **明示的に渡した `fetchPriority` prop の値しか反映されません**（`priority` からは派生しない）。そのため preload と lazy のチェックは緑なのに `fetchpriority` だけ落ちていました。

## 検証

`getImgProps`（`<Image>` が内部で使う関数）を同じ props で直接呼んで確認:

| | `priority` のみ | `priority` + `fetchPriority="high"` |
|---|---|---|
| 出力される `<img>` の `fetchPriority` | `undefined`（属性なし） | `"high"` ✅ |

`tsc --noEmit` 型エラーなし。

## 変更ファイル

- `app/entry/[slug]/components/EntryCover.tsx`（`<Image>` に `fetchPriority="high"` を1行追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
