### PR TITLE
feat: knowsAbout の一般概念を日本語化

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -98,8 +98,6 @@ const structuredData = {
       "@id": `${SiteUrl}/#person`,
       "@type": "Person",
       alternateName: ["鹿野 壮", "かの たけし", "tonkotsuboy", "tonkotsuboy_com"],
-      // Person は「人物」の説明。サイト説明の basicDescription（WebSite 側で使用）とは分け、
-      // about ページの自己紹介と一致させる（捏造なし）。
       familyName: "鹿野",
       givenName: "壮",
       image: {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -99,8 +99,6 @@ const structuredData = {
       "@type": "Person",
       alternateName: ["鹿野 壮", "かの たけし", "tonkotsuboy", "tonkotsuboy_com"],
       // Person は「人物」の説明。サイト説明の basicDescription（WebSite 側で使用）とは分け、
-      // about ページの自己紹介と一致させる（捧造なし）。
-      // Person は「人物」の説明。サイト説明の basicDescription（WebSite 側で使用）とは分け、
       // about ページの自己紹介と一致させる（捏造なし）。
       familyName: "鹿野",
       givenName: "壮",
@@ -115,9 +113,9 @@ const structuredData = {
         "CSS",
         "TypeScript",
         "JavaScript",
-        "Web Frontend",
-        "Web Standards",
-        "AI Agents",
+        "Webフロントエンド",
+        "Web標準",
+        "AIエージェント",
         "Claude Code",
       ],
       name: PersonName,


### PR DESCRIPTION
## 概要

JSON-LD（`Person`）の `knowsAbout` のうち、説明的な一般概念をサイトの主要言語（日本語）に合わせて日本語化します。`html lang="ja"` / `inLanguage: "ja-JP"` の日本語サイトとの整合性を高め、日本語圏の検索意図に寄せる狙いです。

## 変更点

- `app/layout.tsx`: `knowsAbout` の一般概念を日本語化
  - `Web Frontend` → `Webフロントエンド`
  - `Web Standards` → `Web標準`
  - `AI Agents` → `AIエージェント`
  - 技術固有名詞（`CSS` / `TypeScript` / `JavaScript` / `Claude Code`）は世界共通の名称のため **原語のまま維持**
- あわせて `Person` 上部の**重複コメント**（上段に誤字「捧造」を含む）を1つに整理

## 方針（ベストプラクティス）

- 構造化データの説明テキストは**ページの主要言語に合わせる**のが基本 → ja サイトなので一般概念は日本語
- ただし**技術固有名詞は原語維持**（無理に和訳しない）→ ハイブリッドが最適

## テスト方法

- `pnpm tsc --noEmit` / ESLint: パス
- デプロイ後に [Schema Markup Validator](https://validator.schema.org/) で `Person.knowsAbout` が日本語で反映されるか確認推奨（※ `Person`/`WebSite` はリッチリザルト対象外の型なので Rich Results Test では「検出なし」が正常）

🤖 Generated with [Claude Code](https://claude.com/claude-code)