### PR TITLE
feat: about ページの写真グリッドに顔写真を追加

### DIFF
--- a/app/about/page.module.css
+++ b/app/about/page.module.css
@@ -44,7 +44,7 @@
   display: grid;
   height: 150px;
   gap: var(--space-xs);
-  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-columns: repeat(4, 1fr);
 }
 
 .photoCell {

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -161,6 +161,7 @@ const AboutPage: NextPage = () => {
                     fill
                     sizes="(max-width: 768px) 25vw, 160px"
                     className={styles.photo}
+                    priority
                   />
                 </div>
                 <div className={styles.photoCell}>

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -156,10 +156,19 @@ const AboutPage: NextPage = () => {
               <div className={styles.photoGridBottom}>
                 <div className={styles.photoCell}>
                   <Image
+                    src="/profile.jpg"
+                    alt="鹿野 壮の顔写真"
+                    fill
+                    sizes="(max-width: 768px) 25vw, 160px"
+                    className={styles.photo}
+                  />
+                </div>
+                <div className={styles.photoCell}>
+                  <Image
                     src="/images/about/lecture-hall.jpg"
                     alt="大規模勉強会で登壇中の様子"
                     fill
-                    sizes="(max-width: 768px) 33vw, 213px"
+                    sizes="(max-width: 768px) 25vw, 160px"
                     className={styles.photo}
                   />
                 </div>
@@ -168,7 +177,7 @@ const AboutPage: NextPage = () => {
                     src="/images/about/cssnite-osaka.jpg"
                     alt="CSS Nite in Osaka vol.59 集合写真"
                     fill
-                    sizes="(max-width: 768px) 33vw, 213px"
+                    sizes="(max-width: 768px) 25vw, 160px"
                     className={styles.photo}
                   />
                 </div>
@@ -177,7 +186,7 @@ const AboutPage: NextPage = () => {
                     src="/images/about/full-throttle.jpg"
                     alt="Full Throttle but Safe イベントでの鹿野 壮"
                     fill
-                    sizes="(max-width: 768px) 33vw, 213px"
+                    sizes="(max-width: 768px) 25vw, 160px"
                     className={styles.photo}
                   />
                 </div>


### PR DESCRIPTION
## 概要

`Person.image` が参照している顔写真 `/profile.jpg` を、about ページ上部の写真グリッドに**実際に描画**します。

これまで `profile.jpg` は JSON-LD 内でのみ参照され、ページのどこにも表示されていませんでした。Google は「構造化データにだけ存在する画像」より「ページに実際に描画されている画像」を信頼するため、同一 URL の画像を on-page に出すことで image シグナルを補強します。

## 変更点

- `app/about/page.tsx`: 写真グリッド下段の先頭に `/profile.jpg`（顔写真）のセルを追加
  - 既存3枚と新規1枚、計4枚の `sizes` を実寸（25vw / 160px）に合わせて調整
- `app/about/page.module.css`: `.photoGridBottom` を3列 → 4列（`repeat(4, 1fr)`）に変更

## 設計方針

- 既存の `.photoCell` / `.photo` スタイル（`var(--shadow-rest)` + `var(--radius-md)` + glass border）をそのまま再利用 — DESIGN.md の content layer 最小構成に準拠、新規ガラス面は作らない
- 上段の主要2枚（登壇／配信）の比率は変えず、均等列の下段にのみ1枚追加して破綻を回避
- 顔写真は正方形（1194×1194）なので `object-fit: cover` で自然に収まる

## テスト方法

- `pnpm tsc --noEmit` / ESLint（tsx）/ Stylelint（css）: パス
- デプロイ後、about ページ上部の写真グリッドに顔写真が表示されることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)