### PR TITLE
about: プロフィール文を経歴中心に本格化

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -227,19 +227,21 @@ const AboutPage: NextPage = () => {
 
           {/* Bio */}
           <section className={styles.section}>
-            <h2 className={styles.sectionLabel}>自己紹介</h2>
+            <h2 className={styles.sectionLabel}>鹿野 壮（かのたけし）とは</h2>
             <div className={styles.bioCard}>
               <p className={styles.bioText}>
-                Webフロントエンドエンジニアの鹿野 壮（かの たけし）です。TypeScriptとCSSをこよなく愛しています。福岡県出身、現在は東京都日本橋を拠点に活動しています。
+                Ubie株式会社のStaff Product Engineer。福岡県出身、現在は東京都日本橋を拠点に活動しています。
               </p>
               <p className={styles.bioText}>
-                九州大学芸術工学部音響設計学科を卒業後、Webの世界へ。制作会社ICSではテックリードを務め、マネーフォワードでは開発部の副部長兼フロントエンドチームリーダーとして、組織づくりと大規模プロダクトのフロントエンド開発を牽引しました。現在はUbie株式会社でStaff Product Engineerとして、プロダクト開発に取り組んでいます。
+                2024年にUbie株式会社に入社。九州大学でメディアアートを学んだ後、テックリードやフロントエンドチームリーダーを経験する。現在はUbieでフロントエンド・バックエンド問わずフルスタックにプロダクト開発をしている。
+                
+                九州大学芸術工学部音響設計学科を卒業後、ウェブ制作会社にてテックリードを務め、前職マネーフォワードでは開発部の副部長兼フロントエンドチームリーダーを担う。現在はUbie株式会社にて、フロントエンド開発、バックエンド開発、モバイルアプリ開発まで幅広く行う。
               </p>
               <p className={styles.bioText}>
-                とくにTypeScript・CSSを軸としたWebプラットフォーム技術が好きで、暇さえあればコードを書いています。2025年5月にはClaude Codeにタスクを丸投げするおじさんへと転生しました。勉強会・技術SNS・Xなどを通じて、日々学んだことを積極的に発信しています。
+                とくにTypeScript・CSSを軸としたWebプラットフォーム技術を好み、暇さえあればコードを書いている。近年はAIエージェントを中心とした開発をしており、2025年5月にはClaude Codeにタスクを丸投げするおじさんへと転生。
               </p>
               <p className={styles.bioText}>
-                著書に「TypeScriptコードレシピ集」「JavaScript &amp; TypeScript実力強化書」「JavaScriptコードレシピ集」（いずれも技術評論社）。これまでの登壇は50回を超え、CSS Niteベストセッションを受賞。TechFeed Proプロダクトアドバイザー・公認エキスパートも務めています。
+                著書に『TypeScriptコードレシピ集』『JavaScript & TypeScript実力強化書』『JavaScriptコードレシピ集』（いずれも技術評論社）。これまでの登壇は50回を超え、CSS Niteベストセッションを受賞。単独でのイベントでは最大1,200名を集客。TechFeed Proプロダクトアドバイザー・公認エキスパートも務める。
               </p>
             </div>
           </section>

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -230,7 +230,7 @@ const AboutPage: NextPage = () => {
             <h2 className={styles.sectionLabel}>鹿野 壮（かのたけし）とは</h2>
             <div className={styles.bioCard}>
               <p className={styles.bioText}>
-                Ubie株式会社のStaff Product Engineer。福岡県出身、現在は東京都日本橋を拠点に活動しています。
+                Ubie株式会社のStaff Product Engineer。福岡県出身、現在は東京都日本橋を拠点に活動している。
               </p>
               <p className={styles.bioText}>
                 2024年にUbie株式会社に入社。九州大学でメディアアートを学んだ後、テックリードやフロントエンドチームリーダーを経験する。現在はUbieでフロントエンド・バックエンド問わずフルスタックにプロダクト開発をしている。

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -230,13 +230,16 @@ const AboutPage: NextPage = () => {
             <h2 className={styles.sectionLabel}>自己紹介</h2>
             <div className={styles.bioCard}>
               <p className={styles.bioText}>
-                鹿野 壮（かの たけし）といいます。
+                Webフロントエンドエンジニアの鹿野 壮（かの たけし）です。TypeScriptとCSSをこよなく愛しています。福岡県出身、現在は東京都日本橋を拠点に活動しています。
               </p>
               <p className={styles.bioText}>
-                九州大学芸術工学部音響設計学科を卒業後、Ubie株式会社でStaff Product Engineerとして働いています。とくにTypeScript・CSSが好きで、暇があればコードを書いています。2025年5月にClaude Codeにタスク丸投げおじさんとして転生しました。勉強会・技術SNS・Xなどで積極的に技術情報を発信中。
+                九州大学芸術工学部音響設計学科を卒業後、Webの世界へ。制作会社ICSではテックリードを務め、マネーフォワードでは開発部の副部長兼フロントエンドチームリーダーとして、組織づくりと大規模プロダクトのフロントエンド開発を牽引しました。現在はUbie株式会社でStaff Product Engineerとして、プロダクト開発に取り組んでいます。
               </p>
               <p className={styles.bioText}>
-                CSS Niteベストセッション受賞。「JavaScriptコードレシピ集」著者。TechFeed Proプロダクトアドバイザー・公認エキスパート。
+                とくにTypeScript・CSSを軸としたWebプラットフォーム技術が好きで、暇さえあればコードを書いています。2025年5月にはClaude Codeにタスクを丸投げするおじさんへと転生しました。勉強会・技術SNS・Xなどを通じて、日々学んだことを積極的に発信しています。
+              </p>
+              <p className={styles.bioText}>
+                著書に「TypeScriptコードレシピ集」「JavaScript &amp; TypeScript実力強化書」「JavaScriptコードレシピ集」（いずれも技術評論社）。これまでの登壇は50回を超え、CSS Niteベストセッションを受賞。TechFeed Proプロダクトアドバイザー・公認エキスパートも務めています。
               </p>
             </div>
           </section>

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -210,7 +210,10 @@ const AboutPage: NextPage = () => {
                   ) : social.iconType === "lucide-codepen" ? (
                     <Codepen className={styles.socialPillIcon} aria-hidden />
                   ) : social.iconType === "lucide-presentation" ? (
-                    <Presentation className={styles.socialPillIcon} aria-hidden />
+                    <Presentation
+                      className={styles.socialPillIcon}
+                      aria-hidden
+                    />
                   ) : social.iconPath ? (
                     <SimpleIcon
                       path={social.iconPath}
@@ -230,18 +233,21 @@ const AboutPage: NextPage = () => {
             <h2 className={styles.sectionLabel}>鹿野 壮（かのたけし）とは</h2>
             <div className={styles.bioCard}>
               <p className={styles.bioText}>
-                Ubie株式会社のStaff Product Engineer。福岡県出身、現在は東京都日本橋を拠点に活動している。
+                Ubie株式会社のStaff Product
+                Engineer。福岡県出身、現在は東京都日本橋を拠点に活動している。
               </p>
               <p className={styles.bioText}>
-                2024年にUbie株式会社に入社。九州大学でメディアアートを学んだ後、テックリードやフロントエンドチームリーダーを経験する。現在はUbieでフロントエンド・バックエンド問わずフルスタックにプロダクト開発をしている。
-                
-                九州大学芸術工学部音響設計学科を卒業後、ウェブ制作会社にてテックリードを務め、前職マネーフォワードでは開発部の副部長兼フロントエンドチームリーダーを担う。現在はUbie株式会社にて、フロントエンド開発、バックエンド開発、モバイルアプリ開発まで幅広く行う。
+                九州大学芸術工学部音響設計学科を卒業後、ウェブ制作会社にてテックリードを務め、前職マネーフォワードでは開発部の副部長兼フロントエンドチームリーダーを担う。現在はUbie株式会社にて、フロントエンド開発、バックエンド開発、モバイルアプリ開発ド問わずフルスタックにプロダクト開発をしている。
               </p>
               <p className={styles.bioText}>
-                とくにTypeScript・CSSを軸としたWebプラットフォーム技術を好み、暇さえあればコードを書いている。近年はAIエージェントを中心とした開発をしており、2025年5月にはClaude Codeにタスクを丸投げするおじさんへと転生。
+                とくにTypeScript・CSSを軸としたWebプラットフォーム技術を好み、暇さえあればコードを書いている。近年はAIエージェントを中心とした開発をしており、2025年5月にはClaude
+                Codeにタスクを丸投げするおじさんへと転生。
               </p>
               <p className={styles.bioText}>
-                著書に『TypeScriptコードレシピ集』『JavaScript & TypeScript実力強化書』『JavaScriptコードレシピ集』（いずれも技術評論社）。これまでの登壇は50回を超え、CSS Niteベストセッションを受賞。単独でのイベントでは最大1,200名を集客。TechFeed Proプロダクトアドバイザー・公認エキスパートも務める。
+                著書に『TypeScriptコードレシピ集』『JavaScript &
+                TypeScript実力強化書』『JavaScriptコードレシピ集』（いずれも技術評論社）。これまでの登壇は50回を超え、CSS
+                Niteベストセッションを受賞。単独でのイベントでは最大1,200名を集客。TechFeed
+                Proプロダクトアドバイザー・公認エキスパートも務める。
               </p>
             </div>
           </section>
@@ -267,7 +273,9 @@ const AboutPage: NextPage = () => {
                     />
                   </div>
                   <div className={styles.bookInfo}>
-                    <h3 className={clsx(styles.bookTitle, hoverStyles.title)}>{item.title}</h3>
+                    <h3 className={clsx(styles.bookTitle, hoverStyles.title)}>
+                      {item.title}
+                    </h3>
                     <p className={styles.bookPublisher}>{item.publisher}</p>
                   </div>
                   <div className={hoverStyles.arrow}>
@@ -284,9 +292,19 @@ const AboutPage: NextPage = () => {
             <ul className={styles.timelineList}>
               {interviews.map((item) => (
                 <li key={item.title}>
-                  <Link href={item.href} target="_blank" className={clsx(styles.timelineItem, hoverStyles.card)}>
-                    <span className={clsx(styles.timelineTitle, hoverStyles.title)}>{item.title}</span>
-                    <div className={clsx(styles.timelineArrow, hoverStyles.arrow)}>
+                  <Link
+                    href={item.href}
+                    target="_blank"
+                    className={clsx(styles.timelineItem, hoverStyles.card)}
+                  >
+                    <span
+                      className={clsx(styles.timelineTitle, hoverStyles.title)}
+                    >
+                      {item.title}
+                    </span>
+                    <div
+                      className={clsx(styles.timelineArrow, hoverStyles.arrow)}
+                    >
                       <ChevronRight size={20} aria-hidden />
                     </div>
                   </Link>


### PR DESCRIPTION
## 概要

`/about` の自己紹介文を、キャリアの積み上げが伝わる本格的なプロフィールに刷新しました。

## 変更点（bio 本文のみ）

- **書き出し**を肩書き起点に変更（「Webフロントエンドエンジニアの鹿野 壮です」）
- **出身地・在住地**を追記（福岡県出身 / 東京都日本橋拠点）
- **経歴**を時系列で明記
  - マネーフォワード 開発部副部長兼フロントエンドチームリーダー
  - Ubie Staff Product Engineer
- **登壇実績**を「50回を超え」と明記（published 58本の実績から保守的に算出）
- 近著・CSS Nite ベストセッション・TechFeed Pro を整理

## 補足

- Ubie の事業ドメインは断定を避け「プロダクト開発」と表現。
- 経歴タイムライン／数字stat／登壇実績セクションの新設は今回スコープ外。

## 確認

- tcm / velite build / eslint / stylelint / markuplint / vitest（49 passed）すべてパス

https://claude.ai/code/session_018kaDKwBxCjwEXbLKTfVA14

---
_Generated by [Claude Code](https://claude.ai/code/session_018kaDKwBxCjwEXbLKTfVA14)_