### PR TITLE
Add favicon and apple touch icon metadata

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -42,6 +42,14 @@ export const metadata: Metadata = {
     },
   },
   description: basicDescription,
+  icons: {
+    apple: "/apple-touch-icon.png",
+    icon: [
+      { sizes: "any", url: "/favicon.ico" },
+      { sizes: "16x16", type: "image/png", url: "/favicon-16x16.png" },
+      { sizes: "32x32", type: "image/png", url: "/favicon-32x32.png" },
+    ],
+  },
   metadataBase: new URL(SiteUrl),
   openGraph: {
     description: basicDescription,


### PR DESCRIPTION
## Summary
Added favicon and apple touch icon configuration to the site metadata in `app/layout.tsx` to improve browser tab display and iOS home screen appearance.

## Changes
- Added `icons` metadata object with:
  - Apple touch icon (`/apple-touch-icon.png`) for iOS devices
  - Multiple favicon formats for broad browser compatibility:
    - `favicon.ico` (any size, fallback)
    - `favicon-16x16.png` (16x16 PNG)
    - `favicon-32x32.png` (32x32 PNG)

## Implementation Details
The icons are configured using Next.js metadata API's `icons` property, which automatically generates the appropriate `<link>` tags in the HTML head. This follows Next.js best practices for favicon configuration as documented in the metadata file conventions.

https://claude.ai/code/session_011s2xUKroxfynkjZLGvwuHk