### PR TITLE
Add gh-stack introduction article

### DIFF
--- a/content/posts/gh-stack-introduction.md
+++ b/content/posts/gh-stack-introduction.md
@@ -1,5 +1,5 @@
 ---
-title: "GitHubにスタックプルリクエストが登場。gh stackでPRを分割して積み上げよう"
+title: "GitHubにスタック型プルリクエストが登場。gh stackでPRを分割して積み上げよう"
 slug: "gh-stack-introduction"
 date: "2026-07-31T00:00+09:00"
 published: true

--- a/content/posts/gh-stack-introduction.md
+++ b/content/posts/gh-stack-introduction.md
@@ -1,0 +1,13 @@
+---
+title: "GitHubにスタックプルリクエストが登場。gh stackでPRを分割して積み上げよう"
+slug: "gh-stack-introduction"
+date: "2026-07-31T00:00+09:00"
+published: true
+tags: []
+categories: []
+medium: "執筆記事"
+thumbnail: ""
+linkUrl: "https://zenn.dev/ubie_dev/articles/gh-stack-introduction"
+targetUrl: "https://zenn.dev/ubie_dev/articles/gh-stack-introduction"
+hasDetail: false
+---


### PR DESCRIPTION
## Summary
Added a new blog post article about GitHub's stack pull request feature and the `gh stack` command for managing stacked PRs.

## Changes
- Added new post file `content/posts/gh-stack-introduction.md` with metadata for an article about gh-stack
- Article is published and linked to the Zenn platform (external publication)
- Configured with appropriate frontmatter including title, slug, date, and target URL

## Details
The article introduces developers to the gh-stack tool for splitting and stacking pull requests on GitHub. It's published on Zenn and will be included in the portfolio site's content collection via Velite's build process.

https://claude.ai/code/session_01YBPnWN2X6duziBEFtVRgx5