### PR TITLE
スマホのピックアップをコンパクト化し、カードの影・罫線をトークンに統一

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -88,8 +88,8 @@
 ### Glass Card (`.ds-glass`)
 - bg: `--glass-card-bg` / border: `--glass-card-border` / radius: `28px`
 - `backdrop-filter: blur(12px)`（`saturate(180%)` は不要、ヘッダー系専用）
-- shadow (rest): `0 2px 8px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04)` + `inset 0 1px 0 rgba(255,255,255,0.9)`
-- **Hover**: border → `oklch(0.787 0.158 79 / 0.30)`, shadow → elevated, title → `--liquid-primary`
+- shadow (rest): `var(--shadow-rest)` のみ（**内側ハイライトは焼かない** — §6 参照）
+- **Hover**: border → `oklch(0.787 0.158 79 / 0.30)`, shadow → `var(--shadow-elevated)`, title → `--liquid-primary`
 
 ### Primary Button (`.ds-btn-primary`)
 - bg: `linear-gradient(in oklch 180deg, oklch(0.88 0.16 90), oklch(0.787 0.158 79))` / text: `var(--text-on-yellow)`
@@ -149,7 +149,11 @@ Apple HIG Materials は **Liquid Glass を content layer に使わない／spari
 | `shadow-elevated` | `0 10px 30px -5px rgba(0,0,0,0.10), 0 4px 8px -2px rgba(0,0,0,0.04)` | ホバー・開いたメニュー・ヘッダー |
 | `glow-yellow` | `0 0 0 1px oklch(0.787 0.158 79 / 0.25), 0 8px 24px oklch(0.787 0.158 79 / 0.28)` | **`:focus-visible` 時のみ** 点灯（rest 状態で常時光らせない） |
 
-**内側ハイライト** (ガラスの厚み): `inset 0 1px 0 rgba(255,255,255,0.9)`、底辺に `inset 0 -1px 0 rgba(0,0,0,0.05)`。
+**内側ハイライトは content layer のカードに焼かない**（`inset 0 1px 0 rgba(255,255,255,0.9)` のような "ガラスの厚み" 表現）。上端 1px だけが明るく光り、内側ハイライトを持たない隣のカードと縁の見え方が揃わないため。とくにダークテーマでは白 20% の線がはっきり浮く。カード面は `border: 1px solid var(--glass-card-border)` + `var(--shadow-rest)` の 2 点で十分。
+
+**影は必ずトークン参照で書く**（`var(--shadow-rest)` / `var(--shadow-elevated)`）。同じ見た目の値をベタ書きすると、これらのトークンが**テーマ連動**であることを取りこぼす（dark の `--shadow-rest` は light の約 5 倍濃い）。過去に ArticleGrid が `0 2px 8px rgb(0 0 0 / 0.04)` をベタ書きしており、ダークテーマでカードがほぼ無影になっていた。
+
+**サムネイル等の画像コンテナの内枠**は `inset 0 0 0 1px var(--thumbnail-hairline)` を使う（Pickup / ArticleGrid / About 書影で共有）。
 
 **Chrome elevation の統一ルール**: ヘッダー周りの chrome 要素（logo avatar / nav pill / ThemeToggle）は全て `var(--shadow-rest)` に揃える。**active 状態は背景色（`--active-pill-bg` 等）で差別化し、shadow で深さを変えない**。色付き glow を hand-rolled でこれらに焼くと §7 の「光るオブジェクト」アンチパターンに陥る。
 
@@ -159,7 +163,7 @@ Apple HIG Materials は **Liquid Glass を content layer に使わない／spari
 - 色相を持つ値は `oklch()` で書く
 - グラデーションは `linear-gradient(in oklch ...)` のように補間色空間を明示する
 - 背景アンビエントメッシュを必ず敷く
-- カードには **blur + 内側ハイライト** の 2 点セットを守る（`saturate(180%)` はヘッダー系専用）
+- カード面は **`border` + `backdrop-filter: blur(12px)` + `var(--shadow-rest)`** の 3 点で組む（`saturate(180%)` はヘッダー系専用）
 - 動きは `cubic-bezier(0.4, 0, 0.2, 1)` (`--ease-liquid`) を基本に
 - chrome 要素（avatar / nav pill / ThemeToggle）は `var(--shadow-rest)` で立体感を統一する
 - `prefers-reduced-motion` で全モーションを無効化（`globals.css` の universal リセットで `*, *::before, *::after` の `animation-duration` / `transition-duration` を 0.01ms に。**個別コンポーネントで重複ガードを書かない**）
@@ -176,6 +180,9 @@ Apple HIG Materials は **Liquid Glass を content layer に使わない／spari
 - **背景オーブを 4 球以上重ねない**（多色 mesh は AI スタートアップ LP の量産パターン）
 - **`--glow-yellow` を rest 状態の常時シャドウに使わない**（focus-visible 時のみ点灯）
 - **色のついた glow / ドロップシャドウを chrome 要素に hand-roll しない**（`0 4px 12px oklch(0.787 0.158 79 / 0.30)` のような）。chrome は `var(--shadow-rest)` で揃える。色付き影は "光るオブジェクト" として浮いて AI 系 SaaS LP の量産パターンになる
+- **カードに内側ハイライト（`inset 0 1px 0 rgba(255,255,255,...)`）を焼かない**。上端 1px だけが光り、隣り合うカードで縁の見え方が揃わなくなる（§6 参照）
+- **影の値をベタ書きしない**。`var(--shadow-rest)` / `var(--shadow-elevated)` / `var(--thumbnail-hairline)` を参照する。ベタ書きは見た目が同じでも**テーマ連動を失う**（dark の影は light の約 5 倍濃い）
+- **黄色背景（`--liquid-primary`）の上に `white` を置かない**。テキストもアイコンも `var(--text-on-yellow)` を使う（white は 1.99:1 で WCAG 1.4.11 の 3:1 に不足、`--text-on-yellow` なら約 9.9:1）
 - 個別コンポーネントで `:focus-visible` や `@media (prefers-reduced-motion)` を重複指定しない（`globals.css` の universal rule がすでにある）
 - **外部リンクに `rel="noreferrer"` / `rel="noopener"` を付けない**。`target="_blank"` だけで十分。`noopener` は modern browsers が自動付与（ESLint `no-restricted-syntax` で明示も禁止）、`noreferrer` は Referrer-Policy デフォルト `strict-origin-when-cross-origin` で path は元から漏れない（こちらは ESLint 対象外・規約のみ）。origin まで消すと kano.codes 由来のリファラ計測を妨げて先方の Analytics に損。詳細は [`.claude/rules/react-typescript.md`](.claude/rules/react-typescript.md)
 - 絵文字を UI 装飾に散りばめる

--- a/app/about/page.module.css
+++ b/app/about/page.module.css
@@ -175,7 +175,7 @@
   border-radius: var(--radius-sm);
   aspect-ratio: 3 / 4;
   background: var(--bg-primary);
-  box-shadow: inset 0 0 0 1px rgb(0 0 0 / 0.05);
+  box-shadow: inset 0 0 0 1px var(--thumbnail-hairline);
 }
 
 .bookCoverImage {

--- a/app/contact/page.module.css
+++ b/app/contact/page.module.css
@@ -85,12 +85,15 @@
   color: var(--text-on-yellow);
 }
 
-/* Baseline 2024: ライト時は黒、ダーク時は白の X ロゴ背景を `light-dark()` で 1 関数に集約。
-   `color-scheme: light dark` は ThemeProvider が `root.style.colorScheme` で切り替えるので、
-   ユーザーが明示的にライト／ダークを選んだ場合もそれに追従する。 */
+/* ライト時は濃色、ダーク時は白の X ロゴ背景。
+   以前は `light-dark()` で書いていたが、Lightning CSS のダウンレベルが
+   `var(--lightningcss-light, A) var(--lightningcss-dark, B)` を出力する一方で
+   コンパニオンの `--lightningcss-*` 定義が出力されず、値が 2 つ並んで
+   `background` / `color` ごと無効になり、ボックスが透明に落ちていた。
+   テーマ連動はプロジェクト標準のトークン参照で行う（Pickup の .ctaBtn と同じ組み方）。 */
 .x {
-  background: light-dark(oklch(0.267 0.029 256), oklch(0.964 0.002 247));
-  color: light-dark(white, oklch(0.15 0.041 268));
+  background: var(--text-primary);
+  color: var(--bg-primary);
 }
 
 .linkedin {

--- a/app/contact/page.module.css
+++ b/app/contact/page.module.css
@@ -77,9 +77,12 @@
   height: 20px;
 }
 
+/* 黄色背景の上に white を置くと 1.99:1 で WCAG 1.4.11（非テキスト 3:1）に不足するため、
+   .icon の `color: white` を打ち消して --text-on-yellow（約 9.9:1）に差し替える。
+   色付きの影は焼かない（.x / .linkedin と揃わず、これだけ光って浮く）。 */
 .email {
   background: var(--liquid-primary);
-  box-shadow: 0 2px 8px oklch(0.787 0.158 79 / 0.3);
+  color: var(--text-on-yellow);
 }
 
 /* Baseline 2024: ライト時は黒、ダーク時は白の X ロゴ背景を `light-dark()` で 1 関数に集約。

--- a/app/features/pickup/Pickup.module.css
+++ b/app/features/pickup/Pickup.module.css
@@ -178,13 +178,60 @@
   color: var(--text-on-yellow);
 }
 
-/* Responsive */
+/* Responsive
+   モバイルでは縦積みカードがファーストビューを占領してしまうため、
+   ArticleGrid（WORKS）と同じ「左サムネ + 右テキスト」の横並びコンパクトカードに切り替える。
+   subgrid は 1 カラムでは行揃えの役目がないので解除し、素の 2 カラムグリッドとして組み直す。 */
 @media (width <= 768px) {
+  /* WORKS 側の padding-top（--space-sm）と合算した見た目の隙間を 64px → 40px に詰める */
+  .section {
+    padding-bottom: var(--space-md);
+  }
+
   .container {
     padding: 0 var(--space-sm);
   }
 
   .grid {
+    gap: var(--space-sm);
     grid-template-columns: 1fr;
+  }
+
+  /* 4 行 subgrid → 「サムネ | 日付 / タイトル」の 2 列 2 行へ。
+     row/column で gap が別軸になるため、row-gap 単独指定ではなく gap の 2 値指定にする。 */
+  .card {
+    align-items: center;
+    padding: var(--space-sm) var(--space-xs);
+    border-radius: var(--radius-md);
+    gap: var(--space-3xs) var(--space-sm);
+    grid-row: auto;
+    grid-template-columns: 100px 1fr;
+    grid-template-rows: auto auto;
+  }
+
+  /* デスクトップの `margin: 14px 14px 0` を残すと 100px 列を食い潰して下にズレる */
+  .thumb {
+    border-radius: var(--radius-sm);
+    margin: 0;
+    grid-row: span 2;
+  }
+
+  /* デスクトップの `padding: 0 18px` はテキスト列を二重にインデントしてしまう */
+  .date {
+    padding: 0;
+    font-size: 0.75rem;
+    font-weight: 400;
+  }
+
+  .title {
+    padding: 0;
+    font-size: 0.9375rem;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+  }
+
+  /* カード全体がリンクなので CTA ピルは省略できる（WORKS カードにも CTA はない） */
+  .footRow {
+    display: none;
   }
 }

--- a/app/features/pickup/Pickup.module.css
+++ b/app/features/pickup/Pickup.module.css
@@ -81,10 +81,10 @@
   border-radius: var(--radius-lg);
   backdrop-filter: blur(12px);
   background: var(--glass-card-bg);
-  box-shadow:
-    inset 0 1px 0 var(--highlight-top),
-    inset 0 -1px 0 rgb(0 0 0 / 0.04),
-    0 4px 24px rgb(0 0 0 / 0.05);
+
+  /* ArticleGrid（WORKS）カードと同一。内側ハイライト（inset 0 1px 0 var(--highlight-top)）を
+     入れると上端だけ明るい罫線が走り、隣接する WORKS カードと縁の見え方が揃わない。 */
+  box-shadow: 0 2px 8px rgb(0 0 0 / 0.04);
   color: inherit;
   grid-row: span 4;
   grid-template-rows: subgrid;

--- a/app/features/pickup/Pickup.module.css
+++ b/app/features/pickup/Pickup.module.css
@@ -83,8 +83,9 @@
   background: var(--glass-card-bg);
 
   /* ArticleGrid（WORKS）カードと同一。内側ハイライト（inset 0 1px 0 var(--highlight-top)）を
-     入れると上端だけ明るい罫線が走り、隣接する WORKS カードと縁の見え方が揃わない。 */
-  box-shadow: 0 2px 8px rgb(0 0 0 / 0.04);
+     入れると上端だけ明るい罫線が走り、隣接する WORKS カードと縁の見え方が揃わない。
+     影はベタ書きせず --shadow-rest を参照する（テーマ連動。ダークでは light の約 5 倍濃い）。 */
+  box-shadow: var(--shadow-rest);
   color: inherit;
   grid-row: span 4;
   grid-template-rows: subgrid;
@@ -96,11 +97,11 @@
 .thumb {
   position: relative;
   overflow: hidden;
-  border-radius: 14px;
+  border-radius: var(--radius-sm);
   margin: 14px 14px 0;
   aspect-ratio: 16 / 9;
   background: var(--bg-gradient-1);
-  box-shadow: inset 0 0 0 1px rgb(0 0 0 / 0.05);
+  box-shadow: inset 0 0 0 1px var(--thumbnail-hairline);
 }
 
 .thumbImg {
@@ -211,7 +212,6 @@
 
   /* デスクトップの `margin: 14px 14px 0` を残すと 100px 列を食い潰して下にズレる */
   .thumb {
-    border-radius: var(--radius-sm);
     margin: 0;
     grid-row: span 2;
   }

--- a/app/features/pickup/Pickup.module.css
+++ b/app/features/pickup/Pickup.module.css
@@ -82,9 +82,9 @@
   backdrop-filter: blur(12px);
   background: var(--glass-card-bg);
 
-  /* ArticleGrid（WORKS）カードと同一。内側ハイライト（inset 0 1px 0 var(--highlight-top)）を
-     入れると上端だけ明るい罫線が走り、隣接する WORKS カードと縁の見え方が揃わない。
-     影はベタ書きせず --shadow-rest を参照する（テーマ連動。ダークでは light の約 5 倍濃い）。 */
+  /* ArticleGrid（WORKS）カードと同一。内側ハイライト（inset 0 1px 0 rgba(255,255,255,...)）は
+     入れない — 上端だけ明るい罫線が走り、隣接する WORKS カードと縁の見え方が揃わないため。
+     影はベタ書きせずトークンを参照する（テーマ連動。dark は light の約 5 倍濃い）。 */
   box-shadow: var(--shadow-rest);
   color: inherit;
   grid-row: span 4;

--- a/app/features/pickup/Pickup.module.css
+++ b/app/features/pickup/Pickup.module.css
@@ -142,6 +142,7 @@
   font-weight: 700;
   letter-spacing: -0.005em;
   -webkit-line-clamp: 3;
+  line-clamp: 3;
   line-height: 1.55;
 }
 

--- a/app/features/pickup/Pickup.tsx
+++ b/app/features/pickup/Pickup.tsx
@@ -35,7 +35,7 @@ const PickupCard: FC<CardProps> = ({ item, priority = false }) => {
             alt=""
             fill
             className={clsx(styles.thumbImg, item.isLogoLikeThumbnail && styles.thumbImgContain)}
-            sizes="(max-width: 768px) 100vw, 50vw"
+            sizes="(max-width: 768px) 100px, 50vw"
             priority={priority}
           />
         ) : (

--- a/app/features/pickup/Pickup.tsx
+++ b/app/features/pickup/Pickup.tsx
@@ -13,7 +13,13 @@ import type { FC, ReactNode } from "react";
 
 function formatDate(dateStr: string): string {
   const zdt = Temporal.Instant.from(dateStr).toZonedDateTimeISO("Asia/Tokyo");
-  return `${zdt.year}年${zdt.month}月${zdt.day}日`;
+  // 手組みの `${year}年${month}月${day}日` ではなく Intl に寄せる（ArticleGrid と同じ組み方）。
+  // ja-JP の month: "short" は手組みと同一出力（1 桁・2 桁とも実測で一致）。
+  return zdt.toLocaleString("ja-JP", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
 }
 
 type CardProps = {

--- a/app/features/posts/ArticleGrid/ArticleGrid.module.css
+++ b/app/features/posts/ArticleGrid/ArticleGrid.module.css
@@ -62,7 +62,7 @@
   border-radius: var(--radius-full);
   backdrop-filter: blur(10px);
   background: var(--glass-card-bg);
-  box-shadow: 0 2px 8px rgb(0 0 0 / 0.04);
+  box-shadow: var(--shadow-rest);
   color: var(--text-primary);
   font-size: 0.875rem;
   outline: none;
@@ -150,7 +150,7 @@
   border-radius: var(--radius-md);
   backdrop-filter: blur(12px);
   background: var(--glass-card-bg);
-  box-shadow: 0 2px 8px rgb(0 0 0 / 0.04);
+  box-shadow: var(--shadow-rest);
   cursor: pointer;
   gap: var(--space-sm);
 }
@@ -181,7 +181,7 @@
     var(--bg-gradient-1) 0%,
     var(--bg-gradient-2) 100%
   );
-  box-shadow: inset 0 0 0 1px rgb(0 0 0 / 0.05);
+  box-shadow: inset 0 0 0 1px var(--thumbnail-hairline);
 }
 
 .thumbnail::before {

--- a/app/features/posts/ArticleGrid/ArticleGrid.module.css
+++ b/app/features/posts/ArticleGrid/ArticleGrid.module.css
@@ -65,7 +65,6 @@
   box-shadow: var(--shadow-rest);
   color: var(--text-primary);
   font-size: 0.875rem;
-  outline: none;
   transition: border-color 0.2s var(--ease-liquid), box-shadow 0.2s var(--ease-liquid);
 }
 

--- a/app/styles/card-hover.module.css
+++ b/app/styles/card-hover.module.css
@@ -10,7 +10,7 @@
 .card:hover {
   border-color: var(--glass-card-hover-border);
   background: var(--glass-card-hover-bg);
-  box-shadow: 0 10px 30px -5px rgb(0 0 0 / 0.05);
+  box-shadow: var(--shadow-elevated);
 }
 
 .title {

--- a/app/styles/globals.css
+++ b/app/styles/globals.css
@@ -26,10 +26,6 @@
     --text-on-yellow: oklch(0.152 0.018 79);
     --liquid-primary-accessible: oklch(0.407 0.087 64); /* WCAG AA for small text on light bg: 6.06:1 ✅ */
 
-    /* Specular Highlights（白の鏡面ハイライトは rgba を維持） */
-    --highlight-top: rgba(255, 255, 255, 0.9);
-    --highlight-edge: rgba(255, 255, 255, 0.6);
-
     /* Header — Apple Liquid Glass (chrome layer)
        透過した板 + 強い blur + hairline border の 3 要素のみ。
        reflection overlay や specular line は撤去（HIG: use materials sparingly） */
@@ -102,10 +98,6 @@
     --text-secondary: oklch(0.704 0.005 286);
     --text-tertiary: oklch(0.707 0.022 261);
     --liquid-primary-accessible: oklch(0.645 0.139 71); /* standard amber - passes on dark bg */
-
-    /* Specular Highlights */
-    --highlight-top: rgba(255, 255, 255, 0.2);
-    --highlight-edge: rgba(255, 255, 255, 0.1);
 
     /* Header — Dark Liquid Glass
        紫みを除いてほぼ純黒寄りに。透過率を下げて不透明寄りに振り、

--- a/app/styles/globals.css
+++ b/app/styles/globals.css
@@ -47,6 +47,10 @@
     --glass-card-hover-bg: rgba(255, 255, 255, 0.7);
     --glass-card-hover-border: oklch(0.787 0.158 79 / 0.3);
 
+    /* Thumbnail hairline — 画像コンテナの内枠 1px。
+       Pickup / ArticleGrid / About の書影で共有する（黒の透過なので rgba を維持）。 */
+    --thumbnail-hairline: rgba(0, 0, 0, 0.05);
+
     /* Animation Timing */
     --ease-liquid: cubic-bezier(0.4, 0.0, 0.2, 1);
     --dur-fast: 0.15s;


### PR DESCRIPTION
## 概要

スマホで PICKUP の縦積みカードがファーストビューを占領していた件の修正から始まり、そこで露見したスタイルの重複・トークン迂回・アクセシビリティ不備まで直しています。

> **PC への影響について**（レビュー指摘を受けて明記）
> **レイアウト構造は PC・スマホとも変更ありません**（PC は 2 カラム + subgrid の行揃えを維持）。
> ただし **§2 の影・罫線のトークン化はメディアクエリの外（ベースルール）に対する変更なので、PC にも適用されます**。具体的には PC のカードからも内側ハイライト（上端の明るい 1px）が消え、影がテーマ連動トークンに変わります。これは意図した統一で、ダークモードでは影が正しく濃くなる方向の改善です。

## 1. スマホの PICKUP を WORKS と同じ横並びカードに

| | Before | After |
|---|---|---|
| カード高さ | 約 340px | **104px** |
| サムネ | 全幅 16:9 | **100 × 56.25px**（WORKS と完全一致） |
| PICKUP〜WORKS の余白 | 64px | **40px** |
| 画像リクエスト | `w=828` | **`w=384`** |

- `.card` の subgrid を解除し `100px + 1fr` の 2 列グリッドへ。`.thumb` / `.date` / `.title` はラッパー div を持たない `.card` の直接の子（subgrid 成立のための構造）なので、flex 横並びへの移植ではなく **`display: grid` のまま列構成だけ差し替え**ています。TSX の構造変更・新規クラス名ともにゼロ
- CTA ピルはスマホで非表示（カード全体がリンクでアクセシブルネームはタイトルから取れるため情報欠落なし）
- `sizes` を `100vw` → `100px` に修正。**これを直さないと表示だけ小さくなって転送量はむしろ増えていました**

## 2. カードの罫線・影をトークンに統一

内側ハイライト（`inset 0 1px 0 var(--highlight-top)`）で PICKUP だけ上端が光り、隣の WORKS カードと縁の見え方が揃っていませんでした。追ってみると、より根深い問題がありました。

**`--shadow-rest` はテーマ連動トークン**（dark は light の約 5 倍濃い）ですが、ArticleGrid だけが `0 2px 8px rgb(0 0 0 / 0.04)` をベタ書きしており、**ダークモードでカードがほぼ無影**になっていました。他 7 箇所はすべてトークンを使っています。

| 対象 | Before | After |
|---|---|---|
| カード静止時の影（Pickup / ArticleGrid） | ベタ書き ×2 | `var(--shadow-rest)` |
| カード hover の影（共有 `card-hover`） | ベタ書き | `var(--shadow-elevated)` |
| サムネ内枠 1px（Pickup / ArticleGrid / About 書影） | 同一値 ×3 | `var(--thumbnail-hairline)`（新規トークン） |
| 検索インプット静止時の影 | ベタ書き | `var(--shadow-rest)` |
| Pickup サムネの角丸 | `14px` | `var(--radius-sm)` |

角丸をトークンに揃えたことで、モバイル側の `border-radius` 上書きが不要になり削除できています。

## 3. DESIGN.md を実態に合わせる

DESIGN.md は「AI コーディングエージェント向けの仕様書」として参照されますが、§4/§6/§7 が「カードには内側ハイライトを守る」と規定したままでした。実際にはどのカードも持っていないため、**次に UI を触った人（AI 含む）が規約どおりに再導入し、同じズレが再発する状態**でした。規定を削除し、なぜ焼かないのかを明記しています。

§7 Don't には今回の失敗パターンを 3 件追加：内側ハイライトを焼かない / 影をベタ書きしない / 黄色背景に `white` を置かない。未使用になった `--highlight-top` `--highlight-edge` も削除しました。

## 4. アクセシビリティ

**contact のメールアイコンのコントラスト不足**（WCAG 1.4.11）

黄色背景に `.icon` の `color: white` が乗り **1.99:1**。非テキストの要求は 3:1 です。`var(--text-on-yellow)`（約 9.9:1）に差し替え、あわせて `.x` / `.linkedin` に無い黄色のドロップシャドウも削除しました。

**検索インプットのフォーカスリング消失**

`outline: none` でリングを消したまま復活させていませんでした。`globals.css` の universal `:focus-visible` は `.searchBox input`（特異度 0,2,1）に負けるため効いていません。DESIGN.md §7 の「`outline: none` 経由で消した要素は差し戻す」に反していたので削除し、universal ルールに任せています。

## 5. contact の X アイコンが透明に落ちていた

EMAIL（黄）と LINKEDIN（青）は塗りの四角なのに、**X だけ塗りが無くグリフが浮いていました**（ライト・ダーク両方）。

配信 CSS を直接読んだところ、Lightning CSS が `light-dark()` を次のようにダウンレベルしていました。

```css
.x {
  color:      var(--lightningcss-light, #fff) var(--lightningcss-dark, oklch(15% .041 268));
  background: var(--lightningcss-light, oklch(26.7% .029 256)) var(--lightningcss-dark, oklch(96.4% .002 247));
}
```

本来はコンパニオンの `--lightningcss-light` / `--lightningcss-dark` を `:root` に出力し、片方を空値にして値を消す仕組みですが、**その定義が出力されていません**（実測で両方とも空）。結果、両方の `var()` が既定値へフォールバックして値が 2 つ並び、`background` も `color` も宣言ごと無効になって捨てられていました。

ブラウザ側の問題ではありません（`CSS.supports('background', 'light-dark(red, blue)')` は true、素の要素では正しく解決することを確認済み）。

テーマ連動はプロジェクト標準のトークン参照に変更しました。

```css
.x {
  background: var(--text-primary);
  color: var(--bg-primary);
}
```

意図した 4 値のうち 3 値がトークンと完全一致します。残るライト時の前景のみ純白 → `oklch(0.954 0.008 240)` になりますが、L=0.267 の濃紺ボックス上では判別できないことをキャプチャで確認しています。X のブランド的に純白が必須なら `color: white` のベタ書きに変更してください。

## 動作確認

- 実ブラウザ（Chrome DevTools MCP）で **390px / 500px / 1200px / 1400px**、**ライト / ダーク**両テーマを目視 + computed 値の実測
  - サムネ実寸 `100 × 56.25` が WORKS カードと完全一致
  - 320px 相当までコンテナ幅を強制しても横はみ出しなし
  - PC で subgrid の行揃え（日付・タイトル・CTA）が維持されていること
  - contact の 3 アイコンが両テーマで塗りの四角に揃うこと
  - 検索インプットに pill 形状追従の黄色 2px リングが出ること
- `tcm` / `velite build` / `eslint` / `stylelint` / `markuplint` / `vitest`（276 tests）すべてパス
- `check:unused-css` → No unused class selectors

## Web Interface Guidelines チェック結果

上記 4・5 が該当分。日付整形も手組みテンプレートから `Intl`（`toLocaleString`）へ寄せました（ja-JP の `month: "short"` は手組みと同一出力で表示は不変、ArticleGrid と同じ組み方に統一）。

**意図的にガイドラインへ従っていない点**：ガイドラインは見出しへの `text-wrap: balance` を推奨しますが、DESIGN.md §3 が和文での使用を明確に禁止しています（単語境界のない和文では不自然な位置で改行される）。プロジェクトの規約を優先しています。

**未対応（今回のスコープ外）**：`touch-action: manipulation` と `-webkit-tap-highlight-color` が全体で未設定。ArticleGrid の無限スクロールは 50 件超で仮想化なし。検索インプットの `:focus` 影と `blur(10px)`、カテゴリチップの `border-radius: 6px` もトークン外のままです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P6g8eiuHDZSbwduRsgdvfx
