### PR TITLE
Pickup枠をgh-stack-introduction記事に差し替え

### DIFF
--- a/app/features/pickup/buildPickupItems.ts
+++ b/app/features/pickup/buildPickupItems.ts
@@ -11,7 +11,7 @@ import type { Temporal } from "temporal-polyfill-lite";
  * 特別枠としてピン留めする記事・書籍の slug（先頭からの表示順）。
  * 登壇と違い日付フィルタを通さず常に先頭へ固定するため、時間が経っても消えない。
  */
-const PINNED_POST_SLUGS = ["ts-code-recipe", "modern-web-guidance"];
+const PINNED_POST_SLUGS = ["ts-code-recipe", "gh-stack-introduction"];
 
 function postToItem(post: Post): PickupItem {
   const external = post.permalink.startsWith("http");


### PR DESCRIPTION
## Summary
- トップページの Pickup 枠（ピン留め記事）を「GoogleのModern Web Guidanceスキル登場」から「GitHubにスタック型プルリクエストが登場。gh stackでPRを分割して積み上げよう」に差し替え

## Details
- `PINNED_POST_SLUGS` の `modern-web-guidance` を `gh-stack-introduction` に変更

https://claude.ai/code/session_01YBPnWN2X6duziBEFtVRgx5

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBPnWN2X6duziBEFtVRgx5)_